### PR TITLE
fix(deis.go): remove client prefix from import path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO15VENDOREXPERIMENT=1
 
 # the filepath to this repository, relative to $GOPATH/src
-repo_path = github.com/deis/workflow-cli/client
+repo_path = github.com/deis/workflow-cli
 
 HOST_OS := $(shell uname)
 ifeq ($(HOST_OS),Darwin)

--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/deis/pkg/prettyprint"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/apps"
-	"github.com/deis/workflow-cli/client/controller/models/config"
-	"github.com/deis/workflow-cli/client/pkg/git"
-	"github.com/deis/workflow-cli/client/pkg/webbrowser"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/apps"
+	"github.com/deis/workflow-cli/controller/models/config"
+	"github.com/deis/workflow-cli/pkg/git"
+	"github.com/deis/workflow-cli/pkg/webbrowser"
 )
 
 // AppCreate creates an app.

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/auth"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/auth"
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -7,7 +7,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/deis/workflow-cli/client/controller/models/builds"
+	"github.com/deis/workflow-cli/controller/models/builds"
 )
 
 // BuildsList lists an app's builds.

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/certs"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/certs"
 )
 
 // CertsList lists certs registered with the controller.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/deis/pkg/prettyprint"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/models/config"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/models/config"
 )
 
 // ConfigList lists an app's config.

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/models/domains"
+	"github.com/deis/workflow-cli/controller/models/domains"
 )
 
 // DomainsList lists domains registered with an app.

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/deis/workflow-cli/client/pkg/git"
+	"github.com/deis/workflow-cli/pkg/git"
 )
 
 // GitRemote creates a git remote for a deis app.

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/keys"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/keys"
 )
 
 // KeysList lists a user's keys.

--- a/cmd/keys_test.go
+++ b/cmd/keys_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
+	"github.com/deis/workflow-cli/controller/api"
 )
 
 func TestGetKey(t *testing.T) {

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/deis/pkg/prettyprint"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/models/config"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/models/config"
 )
 
 // LimitsList lists an app's limits.

--- a/cmd/perms.go
+++ b/cmd/perms.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/perms"
-	"github.com/deis/workflow-cli/client/pkg/git"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/perms"
+	"github.com/deis/workflow-cli/pkg/git"
 )
 
 // PermsList prints which users have permissions.

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/models/ps"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/models/ps"
 )
 
 // PsList lists an app's processes.

--- a/cmd/releases.go
+++ b/cmd/releases.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/deis/workflow-cli/client/controller/models/releases"
+	"github.com/deis/workflow-cli/controller/models/releases"
 )
 
 // ReleasesList lists an app's releases.

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/deis/pkg/prettyprint"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/models/config"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/models/config"
 )
 
 // TagsList lists an app's tags.

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/controller/models/users"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/controller/models/users"
 )
 
 // UsersList lists users registered with the controller.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/pkg/git"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/pkg/git"
 )
 
 var defaultLimit = -1

--- a/controller/client/http.go
+++ b/controller/client/http.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/version"
 )
 
 // CreateHTTPClient creates a HTTP Client with proper SSL options.

--- a/controller/client/http_test.go
+++ b/controller/client/http_test.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/version"
 )
 
 type fakeHTTPServer struct{}

--- a/controller/client/utils.go
+++ b/controller/client/utils.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/version"
 )
 
 func locateSettingsFile() string {

--- a/controller/models/apps/apps.go
+++ b/controller/models/apps/apps.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 const workflowURLPrefix = "deis."

--- a/controller/models/apps/apps_test.go
+++ b/controller/models/apps/apps_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const appFixture string = `

--- a/controller/models/auth/auth.go
+++ b/controller/models/auth/auth.go
@@ -3,8 +3,8 @@ package auth
 import (
 	"encoding/json"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // Register a new user with the controller.

--- a/controller/models/auth/auth_test.go
+++ b/controller/models/auth/auth_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const registerExpected string = `{"username":"test","password":"opensesame","email":"test@example.com"}`

--- a/controller/models/builds/builds.go
+++ b/controller/models/builds/builds.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List lists an app's builds.

--- a/controller/models/builds/builds_test.go
+++ b/controller/models/builds/builds_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const buildsFixture string = `

--- a/controller/models/certs/certs.go
+++ b/controller/models/certs/certs.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List certs registered with the controller.

--- a/controller/models/certs/certs_test.go
+++ b/controller/models/certs/certs_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/deis/pkg/time"
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const certsFixture string = `

--- a/controller/models/config/config.go
+++ b/controller/models/config/config.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List lists an app's config.

--- a/controller/models/config/config_test.go
+++ b/controller/models/config/config_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const configFixture string = `

--- a/controller/models/domains/domains.go
+++ b/controller/models/domains/domains.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List domains registered with an app.

--- a/controller/models/domains/domains_test.go
+++ b/controller/models/domains/domains_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const domainsFixture string = `

--- a/controller/models/keys/keys.go
+++ b/controller/models/keys/keys.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List keys on a controller.

--- a/controller/models/keys/keys_test.go
+++ b/controller/models/keys/keys_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const keysFixture string = `

--- a/controller/models/perms/perms.go
+++ b/controller/models/perms/perms.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List users that can access an app.

--- a/controller/models/perms/perms_test.go
+++ b/controller/models/perms/perms_test.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const adminFixture string = `

--- a/controller/models/ps/ps.go
+++ b/controller/models/ps/ps.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List an app's processes.

--- a/controller/models/ps/ps_test.go
+++ b/controller/models/ps/ps_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 
 	"github.com/deis/pkg/time"
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const processesFixture string = `

--- a/controller/models/releases/releases.go
+++ b/controller/models/releases/releases.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List lists an app's releases.

--- a/controller/models/releases/releases_test.go
+++ b/controller/models/releases/releases_test.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const releasesFixture string = `

--- a/controller/models/users/users.go
+++ b/controller/models/users/users.go
@@ -3,8 +3,8 @@ package users
 import (
 	"encoding/json"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
 )
 
 // List users registered with the controller.

--- a/controller/models/users/users_test.go
+++ b/controller/models/users/users_test.go
@@ -8,9 +8,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/deis/workflow-cli/client/controller/api"
-	"github.com/deis/workflow-cli/client/controller/client"
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/controller/api"
+	"github.com/deis/workflow-cli/controller/client"
+	"github.com/deis/workflow-cli/version"
 )
 
 const usersFixture string = `

--- a/deis.go
+++ b/deis.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/deis/workflow-cli/client/parser"
+	"github.com/deis/workflow-cli/parser"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/apps.go
+++ b/parser/apps.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/auth.go
+++ b/parser/auth.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/builds.go
+++ b/parser/builds.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/certs.go
+++ b/parser/certs.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/config.go
+++ b/parser/config.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/domains.go
+++ b/parser/domains.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/git.go
+++ b/parser/git.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/keys.go
+++ b/parser/keys.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/limits.go
+++ b/parser/limits.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/perms.go
+++ b/parser/perms.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/ps.go
+++ b/parser/ps.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/releases.go
+++ b/parser/releases.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/tags.go
+++ b/parser/tags.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/users.go
+++ b/parser/users.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/deis/workflow-cli/client/cmd"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 

--- a/parser/version.go
+++ b/parser/version.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"fmt"
 
-	"github.com/deis/workflow-cli/client/version"
+	"github.com/deis/workflow-cli/version"
 	docopt "github.com/docopt/docopt-go"
 )
 


### PR DESCRIPTION
This caused `go get` to fail on this repo.