### PR TITLE
fix(controller): use django HttpResponse for logs

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -168,7 +168,7 @@ func AppLogs(appID string, lines int) error {
 
 // printLogs prints each log line with a color matched to its category.
 func printLogs(logs string) error {
-	for _, log := range strings.Split(logs, `\\n\\n`) {
+	for _, log := range strings.Split(logs, "\n") {
 		category := "unknown"
 		parts := strings.Split(strings.Split(log, " -- ")[0], " ")
 		category = parts[0]


### PR DESCRIPTION
Django Rest Framework will wrap the string with quotes because
of the JSONRenderer. Django's HttpResponse class handles the
application logs as we expect it to. This change reflects the
change in the controller to split logs properly by the newline
character.

port of deis/deis#5004

to be tested with deis/controller#592