### PR TITLE
ref(http.go): improve client error message

### DIFF
--- a/controller/client/http.go
+++ b/controller/client/http.go
@@ -156,9 +156,8 @@ func checkForErrors(res *http.Response, body string) error {
 // CheckConnection checks that the user is connected to a network and the URL points to a valid controller.
 func CheckConnection(client *http.Client, controllerURL url.URL) error {
 	errorMessage := `%s does not appear to be a valid Deis controller.
-Make sure that the Controller URI is correct and the server is running.`
-
-	baseURL := controllerURL.String()
+Make sure that the Controller URI is correct, the server is running and
+your client version is correct.`
 
 	controllerURL.Path = "/v2/"
 
@@ -172,13 +171,13 @@ Make sure that the Controller URI is correct and the server is running.`
 	res, err := client.Do(req)
 
 	if err != nil {
-		fmt.Printf(errorMessage+"\n", baseURL)
+		fmt.Printf(errorMessage+"\n", controllerURL.String())
 		return err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 401 {
-		return fmt.Errorf(errorMessage, baseURL)
+		return fmt.Errorf(errorMessage, controllerURL.String())
 	}
 
 	checkAPICompatibility(res.Header.Get("DEIS_API_VERSION"))


### PR DESCRIPTION
This is shamelessly ported directly from @bacongobbler's deis/deis#5013.

This PR improves the resultant client error message they get when the returned response is incorrect. This is especially important for determining the error message

Old message when using a v2 client with a v1 cluster:

```
http://deis.10.245.1.3.xip.io does not appear to be a valid Deis controller. Make sure that the
Controller URI is correct and the server is running.
```

New message:

```
http://deis.10.245.1.3.xip.io/v2/ does not appear to be a valid Deis controller. Make sure that the
Controller URI is correct and the server is running.
```

Notice the appended /v2/ path, which users can assume this is a v2 client.