### PR TITLE
chore(Makefile): update docker-go-dev to 0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 	GOOS=linux
 endif
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.9.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.10.0
 DEV_ENV_WORK_DIR := /go/src/${repo_path}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_PREFIX_CGO_ENABLED := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}


### PR DESCRIPTION
Includes [version 0.10.1](https://github.com/Masterminds/glide/releases/tag/0.10.1) of the `glide` package manager, among other updates to the standard Go developer support image.