### PR TITLE
style(README.md): move download badge last for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Deis Client
 
-[![Download](https://api.bintray.com/packages/deis/deisci/deis/images/download.svg)](https://bintray.com/deis/deisci/deis/_latestVersion)
 [![Build Status](https://travis-ci.org/deis/workflow-cli.svg?branch=master)](https://travis-ci.org/deis/workflow-cli)
 [![Go Report Card](http://goreportcard.com/badge/deis/workflow-cli)](http://goreportcard.com/report/deis/workflow-cli)
+[![Download](https://api.bintray.com/packages/deis/deisci/deis/images/download.svg)](https://bintray.com/deis/deisci/deis/_latestVersion)
 
 `deis` is a command line utility used to interact with the [Deis](http://deis.io) open source PaaS.
 


### PR DESCRIPTION
The other component repos all list their "download" (Docker registry) link last:
[![Build Status](https://travis-ci.org/deis/minio.svg?branch=master)](https://travis-ci.org/deis/minio) [![Go Report Card](http://goreportcard.com/badge/deis/minio)](http://goreportcard.com/report/deis/minio) [![Docker Repository on Quay](https://quay.io/repository/deisci/minio/status "Docker Repository on Quay")](https://quay.io/repository/deisci/minio)

This improves consistency by moving the bintray download badge last.