### PR TITLE
chore(git): Make builder git remote use different hostname

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -95,10 +95,11 @@ func findRemote(host string) (string, error) {
 
 	// Strip off any trailing :port number after the host name.
 	host = strings.Split(host, ":")[0]
+	builderHost := getBuilderHostname(host)
 
 	for _, line := range strings.Split(cmd, "\n") {
 		for _, remote := range strings.Split(line, " ") {
-			if strings.Contains(remote, host) {
+			if strings.Contains(remote, host) || strings.Contains(remote, builderHost) {
 				return strings.Split(remote, "\t")[1], nil
 			}
 		}
@@ -111,5 +112,12 @@ func findRemote(host string) (string, error) {
 func RemoteURL(host, appID string) string {
 	// Strip off any trailing :port number after the host name.
 	host = strings.Split(host, ":")[0]
-	return fmt.Sprintf("ssh://git@%s:2222/%s.git", host, appID)
+	return fmt.Sprintf("ssh://git@%s:2222/%s.git", getBuilderHostname(host), appID)
+}
+
+// getBuilderHostname derives the builder host name from the controller host name.
+func getBuilderHostname(host string) string {
+	hostTokens := strings.Split(host, ".")
+	hostTokens[0] = fmt.Sprintf("%s-builder", hostTokens[0])
+	return strings.Join(hostTokens, ".")
 }

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -7,15 +7,15 @@ import (
 func TestRemoteURL(t *testing.T) {
 	t.Parallel()
 
-	actual := RemoteURL("example.com", "app")
-	expected := "ssh://git@example.com:2222/app.git"
+	actual := RemoteURL("deis.example.com", "app")
+	expected := "ssh://git@deis-builder.example.com:2222/app.git"
 
 	if actual != expected {
 		t.Errorf("Expected %s, Got %s", expected, actual)
 	}
 
 	actual = RemoteURL("deis.10.245.1.3.xip.io:31350", "velcro-underdog")
-	expected = "ssh://git@deis.10.245.1.3.xip.io:2222/velcro-underdog.git"
+	expected = "ssh://git@deis-builder.10.245.1.3.xip.io:2222/velcro-underdog.git"
 
 	if actual != expected {
 		t.Errorf("Expected %s, Got %s", expected, actual)


### PR DESCRIPTION
This transitions the CLI from creating git `deis` git remotes that use the same hostname as the controller to using one with a hostname _derived_ from the controller's hostname.

This is to support the contingency wherein some scenario has forced an admin to use _two_ different load balancers-- one for builder and another for everything else.

See https://github.com/deis/controller/issues/657 for further context.