### PR TITLE
fix(cmd): strip printLogs with only one newline

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -172,7 +172,7 @@ func AppLogs(appID string, lines int) error {
 
 // printLogs prints each log line with a color matched to its category.
 func printLogs(logs string) error {
-	for _, log := range strings.Split(logs, "\\n\\n") {
+	for _, log := range strings.Split(logs, `\n`) {
 		category := "unknown"
 		parts := strings.Split(strings.Split(log, " -- ")[0], " ")
 		category = parts[0]


### PR DESCRIPTION
refs deis/workflow#202