### PR TITLE
fix(cmd): split only twice at most

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -121,7 +121,7 @@ func parseInfos(items []string) map[string]interface{} {
 }
 
 func parseInfo(item string) (string, string, error) {
-	parts := strings.Split(item, "=")
+	parts := strings.SplitN(item, "=", 2)
 
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf(`%s is invalid, Must be in format key=value

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "testing"
+
+func TestParseInfo(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for passwords with equals signs, such as a gcr.io token
+	key := `password=ihaveanequalssign=`
+	if _, _, err := parseInfo(key); err != nil {
+		t.Errorf("failed to parse valid token with equals sign: got (%s)", err)
+	}
+}


### PR DESCRIPTION
If the value contains an equals sign, the parsing logic fails.