### PR TITLE
ref(cmd): clarify deis registry usage

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -124,8 +124,12 @@ func parseInfo(item string) (string, string, error) {
 	parts := strings.SplitN(item, "=", 2)
 
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf(`%s is invalid, Must be in format key=value
+		return "", "", fmt.Errorf(`%s is invalid. Must be in format key=value
 Examples: username=bob password=s3cur3pw1`, item)
+	}
+
+	if parts[0] != "username" && parts[0] != "password" {
+		return "", "", fmt.Errorf(`%s is invalid. Valid keys are "username" or "password".`, parts[0])
 	}
 
 	return parts[0], parts[1], nil

--- a/cmd/registry_test.go
+++ b/cmd/registry_test.go
@@ -5,9 +5,22 @@ import "testing"
 func TestParseInfo(t *testing.T) {
 	t.Parallel()
 
-	// Regression test for passwords with equals signs, such as a gcr.io token
-	key := `password=ihaveanequalssign=`
-	if _, _, err := parseInfo(key); err != nil {
-		t.Errorf("failed to parse valid token with equals sign: got (%s)", err)
+	// keys can only be username or password
+	goodKeys := []string{
+		"username=bob",
+		"password=isyouruncle",
+		// regression test for passwords with equals signs, such as a gcr.io token
+		"password=ihaveanequalssign=",
+	}
+
+	for _, key := range goodKeys {
+		if _, _, err := parseInfo(key); err != nil {
+			t.Errorf("failed parsing valid keys, got (%s)", err)
+		}
+	}
+
+	badKey := "usrname=bob"
+	if _, _, err := parseInfo(badKey); err == nil {
+		t.Errorf("failed erroring on bad key '%s'", badKey)
 	}
 }

--- a/parser/registry.go
+++ b/parser/registry.go
@@ -61,15 +61,17 @@ Options:
 
 func registrySet(argv []string) error {
 	usage := `
-Sets registry information for an application.
-
-key/value pairs used to configure / authenticate against external registries
+Sets registry information for an application. These credentials are the same as those used for
+'docker login' to the private registry.
 
 Usage: deis registry:set [options] <key>=<value>...
 
 Arguments:
-  <key> the registry key, for example: "username" or "password"
-  <value> the registry value, for example: "bob" or "s3cur3pw1"
+  <key>
+    the uniquely identifiable name for logging into the registry. Valid keys are "username" or
+    "password"
+  <value>
+    the value of said environment variable. For example, "bob" or "mysecretpassword"
 
 Options:
   -a --app=<app>


### PR DESCRIPTION
related to deis/workflow#239. Also increases test coverage around this so a user cannot accidentally fat-finger an invalid key.