### PR TITLE
chore(version): bump client version to 2.0.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version identifies this Deis product revision.
-const Version = "2.0.0-dev"
+const Version = "2.0.0"
 
 // APIVersion identifies the latest Deis api version
 const APIVersion = "2.0"


### PR DESCRIPTION
DO NOT MERGE until we are ready to release 2.0.0. Just bumping this to close #70.