### PR TITLE
feat(apps): print output from command to stderr if the command failed

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -202,7 +202,12 @@ func AppRun(appID, command string) error {
 		return err
 	}
 
-	fmt.Print(out.Output)
+	if out.ReturnCode == 0 {
+		fmt.Print(out.Output)
+	} else {
+		fmt.Fprint(os.Stderr, out.Output)
+	}
+
 	os.Exit(out.ReturnCode)
 	return nil
 }


### PR DESCRIPTION
Fixes #69 

Ideally we would direct individual lines to STDOUT and STDERR based on what the command itself does... however, the kubernetes api does not distinguish between the STDOUT and STDERR, so I'm not sure that is possible. I think this is probably the best we can do until we get interactive run sessions implemented.