### PR TITLE
feat(deis.go): implement `deis healthchecks` client commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -90,6 +90,16 @@ func ConfigSet(appID string, configVars []string) error {
 		configMap["SSH_KEY"] = base64.StdEncoding.EncodeToString([]byte(sshKey))
 	}
 
+	// NOTE(bacongobbler): check if the user is using the old way to set healthchecks. If so,
+	// send them a deprecation notice.
+	for key, _ := range configMap {
+		if strings.Contains(key, "HEALTHCHECK_") {
+			fmt.Println(`Hey there! We've noticed that you're using 'deis config:set HEALTHCHECK_URL'
+to set up healthchecks. This functionality has been deprecated. In the future, please use
+'deis healthchecks' to set up application health checks. Thanks!`)
+		}
+	}
+
 	fmt.Print("Creating config... ")
 
 	quit := progress()

--- a/cmd/healthchecks.go
+++ b/cmd/healthchecks.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/deis/controller-sdk-go/api"
+	"github.com/deis/controller-sdk-go/config"
+)
+
+// HealthchecksList lists an app's healthchecks.
+func HealthchecksList(appID string) error {
+	c, appID, err := load(appID)
+
+	if err != nil {
+		return err
+	}
+
+	config, err := config.List(c, appID)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("=== %s Healthchecks\n\n", appID)
+
+	fmt.Println("--- Liveness")
+	if livenessProbe, found := config.Healthcheck["livenessProbe"]; found {
+		fmt.Println(livenessProbe)
+	} else {
+		fmt.Println("No liveness probe configured.")
+	}
+
+	fmt.Println("\n--- Readiness")
+	if readinessProbe, found := config.Healthcheck["readinessProbe"]; found {
+		fmt.Println(readinessProbe)
+	} else {
+		fmt.Println("No readiness probe configured.")
+	}
+	return nil
+}
+
+// HealthchecksSet sets an app's healthchecks.
+func HealthchecksSet(appID, healthcheckType string, probe *api.Healthcheck) error {
+	c, appID, err := load(appID)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Applying %s healthcheck... ", healthcheckType)
+
+	quit := progress()
+	configObj := api.Config{}
+	configObj.Healthcheck = make(map[string]*api.Healthcheck)
+
+	configObj.Healthcheck[healthcheckType] = probe
+
+	_, err = config.Set(c, appID, configObj)
+
+	quit <- true
+	<-quit
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("done\n\n")
+
+	return HealthchecksList(appID)
+}
+
+// HealthchecksUnset removes an app's healthchecks.
+func HealthchecksUnset(appID string, healthchecks []string) error {
+	c, appID, err := load(appID)
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("Removing healthchecks... ")
+
+	quit := progress()
+
+	configObj := api.Config{}
+
+	healthcheckMap := make(map[string]*api.Healthcheck)
+
+	for _, healthcheck := range healthchecks {
+		healthcheckMap[healthcheck] = nil
+	}
+
+	configObj.Healthcheck = healthcheckMap
+
+	_, err = config.Set(c, appID, configObj)
+
+	quit <- true
+	<-quit
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Print("done\n\n")
+
+	return HealthchecksList(appID)
+}

--- a/deis.go
+++ b/deis.go
@@ -43,6 +43,7 @@ Subcommands, use 'deis help [subcommand]' to learn more::
   config        manage environment variables that define app config
   domains       manage and assign domain names to your applications
   git           manage git for applications
+  healthchecks  manage healthchecks for applications
   keys          manage ssh keys used for 'git push' deployments
   limits        manage resource limits for your application
   perms         manage permissions for applications
@@ -98,6 +99,8 @@ Use 'git push deis master' to deploy to an application.
 		err = parser.Domains(argv)
 	case "git":
 		err = parser.Git(argv)
+	case "healthchecks":
+		err = parser.Healthchecks(argv)
 	case "help":
 		fmt.Print(usage)
 		return 0

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: efb390ce6569c895e553582bd010493901e3fa4733fb9037970003c870cb5df2
-updated: 2016-06-22T22:40:27.56890943Z
+updated: 2016-06-27T11:56:08.014343879-07:00
 imports:
 - name: github.com/deis/controller-sdk-go
-  version: 3b277af9c00d5e5368862e09effa8ac18c93c0a3
+  version: 3b6502cecedc6ebd7b0f42a8c01c31e8292d1e0d
   subpackages:
   - api
   - apps
@@ -35,7 +35,7 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
 - name: golang.org/x/crypto
-  version: f3241ce8505855877cc8a9717bd61a0f7c4ea83c
+  version: 811831de4c4dd03a0b8737233af3b36852386373
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net

--- a/parser/healthchecks.go
+++ b/parser/healthchecks.go
@@ -1,0 +1,253 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/deis/workflow-cli/cmd"
+
+	"github.com/deis/controller-sdk-go/api"
+	docopt "github.com/docopt/docopt-go"
+)
+
+// Healthchecks routes ealthcheck commands to their specific function
+func Healthchecks(argv []string) error {
+	usage := `
+Valid commands for healthchecks:
+
+healthchecks:list        list healthchecks for an app
+healthchecks:set         set healthchecks for an app
+healthchecks:unset       unset healthchecks for an app
+
+Use 'deis help [command]' to learn more.
+`
+
+	switch argv[0] {
+	case "healthchecks:list":
+		return healthchecksList(argv)
+	case "healthchecks:set":
+		return healthchecksSet(argv)
+	case "healthchecks:unset":
+		return healthchecksUnset(argv)
+	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "healthchecks" {
+			argv[0] = "healthchecks:list"
+			return healthchecksList(argv)
+		}
+
+		PrintUsage()
+		return nil
+	}
+}
+
+func healthchecksList(argv []string) error {
+	usage := `
+Lists healthchecks for an application.
+
+Usage: deis healthchecks:list [options]
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name of the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.HealthchecksList(safeGetValue(args, "--app"))
+}
+
+func healthchecksSet(argv []string) error {
+	usage := `
+Sets healthchecks for an application.
+
+By default, Workflow only checks that the application starts in their Container. A health
+check may be added by configuring a health check probe for the application. The health
+checks are implemented as Kubernetes Container Probes. A 'liveness' and a 'readiness'
+probe can be configured, and each probe can be of type 'httpGet', 'exec' or 'tcpSocket'
+depending on the type of probe the Container requires.
+
+A 'liveness' probe is useful for applications running for long periods of time, eventually
+transitioning to broken states and cannot recover except by restarting them.
+
+Other times, a 'readiness' probe is useful when the Container is only temporarily unable
+to serve, and will recover on its own. In this case, if a Container fails its 'readiness'
+probe, the Container will not be shut down, but rather the Container will stop receiving
+incoming requests.
+
+'httpGet' probes are just as it sounds: it performs a HTTP GET operation on the Container.
+A response code inside the 200-399 range is considered a pass. 'httpGet' probes accept a
+port number to perform the HTTP GET operation on the Container.
+
+'exec' probes run a command inside the Container to determine its health. An exit code of
+zero is considered a pass, while a non-zero status code is considered a fail. 'exec'
+probes accept a string of arguments to be run inside the Container.
+
+'tcpSocket' probes attempt to open a socket in the Container. The Container is only
+considered healthy if the check can establish a connection. 'tcpSocket' probes accept a
+port number to perform the socket connection on the Container.
+
+Usage: deis healthchecks:set <health-type> <probe-type> [options] [--] <args>...
+
+Arguments:
+  <health-type>
+    the healthcheck type, such as 'liveness' or 'readiness'.
+  <probe-type>
+    the healthcheck probe type, such as 'httpGet', 'exec' or 'tcpSocket'.
+  <args>
+    The arguments required for the healthcheck probe. 'exec', accepts a list of arguments;
+    'httpGet' and 'tcpSocket' accept a port number.
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+  -p --path=<path>
+    the relative URL path for 'httpGet' probes. [default: /]
+  --header=<header>...
+    the HTTP headers to send for 'httpGet' probes, separated by commas.
+  --initial-delay-timeout=<initial-delay-timeout>
+    the initial delay timeout for the probe [default: 50]
+  --timeout-seconds=<timeout-seconds>
+    the number of seconds after which the probe times out [default: 50]
+  --period-seconds=<period-seconds>
+    how often (in seconds) to perform the probe [default: 10]
+  --success-threshold=<success-threshold>
+    minimum consecutive successes for the probe to be considered successful after having failed [default: 1]
+  --failure-threshold=<failure-threshold>
+    minimum consecutive successes for the probe to be considered failed after having succeeded [default: 3]
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	app := safeGetValue(args, "--app")
+	path := safeGetValue(args, "--path")
+	initialDelayTimeout := safeGetInt(args, "--initial-delay-timeout")
+	timeoutSeconds := safeGetInt(args, "--timeout-seconds")
+	periodSeconds := safeGetInt(args, "--period-seconds")
+	successThreshold := safeGetInt(args, "--success-threshold")
+	failureThreshold := safeGetInt(args, "--failure-threshold")
+	headers := []string{}
+	if args["--headers"] != nil {
+		headers = args["--headers"].([]string)
+	}
+
+	healthcheckType := args["<health-type>"].(string)
+	probeType := args["<probe-type>"].(string)
+	probeArgs := args["<args>"].([]string)
+
+	if healthcheckType != "liveness" && healthcheckType != "readiness" {
+		return fmt.Errorf("Invalid healthcheck type. Must be one of: \"liveness\", \"readiness\"")
+	}
+
+	// NOTE(bacongobbler): k8s healthchecks use the term "livenessProbe" and "readinessProbe", so let's
+	// add that to the end of the healthcheck type so the controller sees the right probe type
+	healthcheckType += "Probe"
+
+	probe := &api.Healthcheck{
+		InitialDelaySeconds: initialDelayTimeout,
+		TimeoutSeconds:      timeoutSeconds,
+		PeriodSeconds:       periodSeconds,
+		SuccessThreshold:    successThreshold,
+		FailureThreshold:    failureThreshold,
+	}
+
+	switch probeType {
+	case "httpGet":
+		parsedHeaders, err := parseHeaders(headers)
+		if err != nil {
+			return fmt.Errorf("could not parse headers: %s", err)
+		}
+		port, err := strconv.Atoi(probeArgs[0])
+		if err != nil {
+			return fmt.Errorf("could not parse port: %s", err)
+		}
+		probe.HTTPGet = &api.HTTPGetProbe{
+			Path:        path,
+			Port:        port,
+			HTTPHeaders: parsedHeaders,
+		}
+	case "exec":
+		probe.Exec = &api.ExecProbe{
+			Command: probeArgs,
+		}
+	case "tcpSocket":
+		port, err := strconv.Atoi(probeArgs[0])
+		if err != nil {
+			return fmt.Errorf("could not parse port: %s", err)
+		}
+		probe.TCPSocket = &api.TCPSocketProbe{
+			Port: port,
+		}
+	default:
+		return fmt.Errorf("Invalid probe type. Must be one of: \"httpGet\", \"exec\"")
+	}
+	return cmd.HealthchecksSet(app, healthcheckType, probe)
+}
+
+func healthchecksUnset(argv []string) error {
+	usage := `
+Unsets healthchecks for an application.
+
+Usage: deis healthchecks:unset [options] <type>...
+
+Arguments:
+  <type>
+    the healthcheck type, such as 'liveness' or 'readiness'.
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	app := safeGetValue(args, "--app")
+	healthchecks := args["<type>"].([]string)
+
+	// NOTE(bacongobbler): k8s healthchecks use the term "livenessProbe" and "readinessProbe", so let's
+	// add that to the end of the healthcheck type so the controller sees the right probe type
+	for healthcheck := range healthchecks {
+		healthchecks[healthcheck] += "Probe"
+	}
+
+	return cmd.HealthchecksUnset(app, healthchecks)
+}
+
+func parseHeaders(headers []string) ([]*api.KVPair, error) {
+	var parsedHeaders []*api.KVPair
+	for _, header := range headers {
+		parsedHeader, err := parseHeader(header)
+		if err != nil {
+			return nil, err
+		}
+		parsedHeaders = append(parsedHeaders, parsedHeader)
+	}
+	return parsedHeaders, nil
+}
+
+func parseHeader(header string) (*api.KVPair, error) {
+	headerParts := strings.SplitN(header, ":", 2)
+	if len(headerParts) != 2 {
+		return nil, fmt.Errorf("could not find separator in header (%s)", header)
+	}
+	return &api.KVPair{
+		Key:   strings.TrimSpace(headerParts[0]),
+		Value: strings.TrimSpace(headerParts[1]),
+	}, nil
+}

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 )
@@ -11,6 +12,17 @@ func safeGetValue(args map[string]interface{}, key string) string {
 		return ""
 	}
 	return args[key].(string)
+}
+
+func safeGetInt(args map[string]interface{}, key string) int {
+	if args[key] == nil {
+		return 0
+	}
+	retVal, err := strconv.Atoi(args[key].(string))
+	if err != nil {
+		log.Fatalf("could not convert %s to int: %v", args[key], err)
+	}
+	return retVal
 }
 
 func responseLimit(limit string) (int, error) {

--- a/parser/utils_test.go
+++ b/parser/utils_test.go
@@ -32,6 +32,25 @@ func TestSafeGetNil(t *testing.T) {
 	}
 }
 
+func TestSafeGetInt(t *testing.T) {
+	t.Parallel()
+
+	expected := 1
+
+	test := make(map[string]interface{}, 1)
+	test["test"] = "1"
+
+	actual := safeGetInt(test, "test")
+
+	if expected != actual {
+		t.Errorf("Expected %d, Got %d", expected, actual)
+	}
+
+	if actual = safeGetInt(test, "foo"); actual != 0 {
+		t.Errorf("Expected 0, Got %d", actual)
+	}
+}
+
 func TestPrintHelp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This is the client-side implementation for deis/workflow#322.

TODO:

 - [x] add deprecation notice for anyone setting HEALTHCHECK_*
 - [x] remove bacongobbler alias from glide.yaml before merging

depends on https://github.com/deis/controller-sdk-go/pull/10