### PR TITLE
fix(ps): match controller regexp for ps names

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -41,7 +41,7 @@ func PsScale(appID string, targets []string) error {
 	}
 
 	targetMap := make(map[string]int)
-	regex := regexp.MustCompile("^([A-z]+)=([0-9]+)$")
+	regex := regexp.MustCompile("^([a-z0-9]+)=([0-9]+)$")
 
 	for _, target := range targets {
 		if regex.MatchString(target) {


### PR DESCRIPTION
The client side and server side checks for valid process names were different, so each would accept different names. This updated the client to use the [regexp as the controller](https://github.com/deis/controller/blob/master/rootfs/api/serializers.py#L15-L17)

Fixes #88