### PR TITLE
feat(deis): add `deis shortcuts` command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,22 @@
+package cli
+
+var Shortcuts = map[string]string{
+	"create":         "apps:create",
+	"destroy":        "apps:destroy",
+	"info":           "apps:info",
+	"login":          "auth:login",
+	"logout":         "auth:logout",
+	"logs":           "apps:logs",
+	"open":           "apps:open",
+	"passwd":         "auth:passwd",
+	"pull":           "builds:create",
+	"register":       "auth:register",
+	"rollback":       "releases:rollback",
+	"run":            "apps:run",
+	"scale":          "ps:scale",
+	"sharing":        "perms:list",
+	"sharing:list":   "perms:list",
+	"sharing:add":    "perms:create",
+	"sharing:remove": "perms:delete",
+	"whoami":         "auth:whoami",
+}

--- a/cmd/shortcuts.go
+++ b/cmd/shortcuts.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/deis/workflow-cli/cli"
+)
+
+// Shortcuts displays all relevant shortcuts for the CLI.
+func ShortcutsList() error {
+	var (
+		strBuilder string = ""
+		keys       []string
+	)
+
+	// NOTE(bacongobbler): go does not guarantee an iteration order when iterating over a map,
+	// so to work around this we can sort the keys and iterate using the key array
+	for k := range cli.Shortcuts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		strBuilder += fmt.Sprintf("%s -> %s\n", k, cli.Shortcuts[k])
+	}
+
+	fmt.Println(strBuilder)
+
+	return nil
+}

--- a/deis.go
+++ b/deis.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/deis/workflow-cli/cli"
 	"github.com/deis/workflow-cli/parser"
 	docopt "github.com/docopt/docopt-go"
 )
@@ -116,6 +117,8 @@ Use 'git push deis master' to deploy to an application.
 		err = parser.Registry(argv)
 	case "releases":
 		err = parser.Releases(argv)
+	case "shortcuts":
+		err = parser.Shortcuts(argv)
 	case "tags":
 		err = parser.Tags(argv)
 	case "users":
@@ -192,28 +195,7 @@ func parseArgs(argv []string) (string, []string) {
 }
 
 func replaceShortcut(command string) string {
-	shortcuts := map[string]string{
-		"create":         "apps:create",
-		"destroy":        "apps:destroy",
-		"info":           "apps:info",
-		"login":          "auth:login",
-		"logout":         "auth:logout",
-		"logs":           "apps:logs",
-		"open":           "apps:open",
-		"passwd":         "auth:passwd",
-		"pull":           "builds:create",
-		"register":       "auth:register",
-		"rollback":       "releases:rollback",
-		"run":            "apps:run",
-		"scale":          "ps:scale",
-		"sharing":        "perms:list",
-		"sharing:list":   "perms:list",
-		"sharing:add":    "perms:create",
-		"sharing:remove": "perms:delete",
-		"whoami":         "auth:whoami",
-	}
-
-	expandedCommand := shortcuts[command]
+	expandedCommand := cli.Shortcuts[command]
 	if expandedCommand == "" {
 		return command
 	}

--- a/parser/shortcuts.go
+++ b/parser/shortcuts.go
@@ -1,0 +1,50 @@
+package parser
+
+import (
+	"github.com/deis/workflow-cli/cmd"
+	docopt "github.com/docopt/docopt-go"
+)
+
+// Shortcuts displays all relevant shortcuts for the CLI.
+func Shortcuts(argv []string) error {
+	usage := `
+Valid commands for shortcuts:
+
+shortcuts:list       list all relevant shortcuts for the CLI
+
+Use 'deis help [command]' to learn more.
+`
+
+	switch argv[0] {
+	case "shortcuts:list":
+		return shortcutsList(argv)
+	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "shortcuts" {
+			argv[0] = "shortcuts:list"
+			return shortcutsList(argv)
+		}
+
+		PrintUsage()
+		return nil
+	}
+}
+
+func shortcutsList(argv []string) error {
+	usage := `
+Lists all relevant shortcuts for the CLI
+
+Usage: deis shortcuts:list
+`
+
+	_, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.ShortcutsList()
+}


### PR DESCRIPTION
This used to be a CLI command, but was lost in the great Go client refactor way back in Deis v1. We still reference it in `deis help` though.