### PR TITLE
fix(ps): restarting a single pod created by Deployments was not working

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -91,9 +91,10 @@ func PsRestart(appID, target string) error {
 
 	if target != "" {
 		if strings.Contains(target, "-") {
-			parts := strings.Split(target, "-")
+			replaced := strings.Replace(target, appID + "-", "", 1)
+			parts := strings.Split(replaced, "-")
 			// the API requires the type, for now
-			psType = parts[len(parts)-2]
+			psType = parts[0]
 			// process name is the full pod
 			psName = target
 		} else {


### PR DESCRIPTION
Deployments created a different pod name then what RCs do (we have less flexibility): oddest-lungfish-cmd-1269180282-60byi

This way we know the proc type is always at the front of the slice, after replacing the app name