### PR TITLE
ref(travis): remove vendor cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: generic
 branches:
   only:
   - master
-cache:
-  directories:
-  - vendor
 services:
 - docker
 sudo: required


### PR DESCRIPTION
This cache directory was useful when glide was slow downloading k8s.io/kubernetes, but updates have
made fetches significantly quicker. The cache has been recently giving us more headaches with the
new SDK, so removing this should make builds more reliable again.