### PR TITLE
fix(glide.yaml): pin the SDK version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 vendor
 deis
 _dist
+workflow-cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -15,3 +15,4 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/olekukonko/tablewriter
 - package: github.com/deis/controller-sdk-go
+  version: e286df036c597f00f071bb77fea595974d6f14dc


### PR DESCRIPTION
This patch also updates the `.gitignore` to exclude host-built binaries (built with `go build`)