### PR TITLE
fix(scale):dont call controller if there is no valid scale pattern

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -53,7 +53,7 @@ func PsScale(appID string, targets []string) error {
 				return err
 			}
 		} else {
-			fmt.Printf("'%s' does not match the pattern 'type=num', ex: web=2\n", target)
+			return fmt.Errorf("'%s' does not match the pattern 'type=num', ex: web=2\n", target)
 		}
 	}
 

--- a/cmd/ps_test.go
+++ b/cmd/ps_test.go
@@ -1,6 +1,39 @@
 package cmd
 
-import "testing"
+import (
+	"github.com/deis/workflow-cli/settings"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestScaleFail(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "tmpdir")
+	if err != nil {
+		t.Fatalf("error creating temp directory (%s)", err)
+	}
+	err = os.Mkdir(tmpDir+"/.deis", 0666)
+	if err != nil {
+		t.Fatalf("error creating temp directory (%s)", err)
+	}
+	os.Setenv("DEIS_PROFILE", "testing")
+	settings.SetHome(tmpDir)
+	data := []byte(`{"username":"test","ssl_verify":false,"controller":"http://deis.127.0.0.1.nip.io","token":"test","response_limit":0}`)
+	if err := ioutil.WriteFile(tmpDir+"/.deis/testing.json", data, 0644); err != nil {
+		t.Fatalf("error creating %s/.deis/testing.json (%s)", tmpDir, err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			t.Fatalf("failed to remove creds file from %s (%s)", tmpDir, err)
+		}
+	}()
+
+	expected := "'web=-1' does not match the pattern 'type=num', ex: web=2\n"
+	actual := PsScale("testApp", []string{"web=-1"})
+	if actual.Error() != expected {
+		t.Errorf("Expected %s, Got %s", expected, actual)
+	}
+}
 
 func TestParseType(t *testing.T) {
 	t.Parallel()
@@ -20,7 +53,6 @@ func TestParseType(t *testing.T) {
 	if psType != "cmd" || psName != deployPod {
 		t.Errorf("type was not cmd (got %s) or psName was not %s (got %s)", psType, deployPod, psName)
 	}
-
 
 	// test type by itself
 	psType, psName = parseType("cmd", "fake")


### PR DESCRIPTION
Output before:
```
keerthanmala$ deis scale web=-1
'web=-1' does not match the pattern 'type=num', ex: web=2
Scaling processes... but first, coffee!
done in 0s
=== woodsy-jokester Processes
--- cmd:
woodsy-jokester-v2-cmd-zbonf up (v2)
```
after:
```
deis scale web=-1 -a=woodsy-jokester
'web=-1' does not match the pattern 'type=num', ex: web=2
```