### PR TITLE
bug(cmd): add more advanced handling of app urls

### DIFF
--- a/cmd/apps_test.go
+++ b/cmd/apps_test.go
@@ -16,3 +16,29 @@ func TestPrintLogLinesBadLine(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+type expandURLCases struct {
+	Input    string
+	Expected string
+}
+
+func TestExpandUrl(t *testing.T) {
+	checks := []expandURLCases{
+		expandURLCases{
+			Input:    "test.com",
+			Expected: "test.com",
+		},
+		expandURLCases{
+			Input:    "test",
+			Expected: "test.foo.com",
+		},
+	}
+
+	for _, check := range checks {
+		out := expandURL("deis.foo.com", check.Input)
+
+		if out != check.Expected {
+			t.Errorf("Expected %s, Got %s", check.Expected, out)
+		}
+	}
+}


### PR DESCRIPTION
Previously, we took a very naive approach to determining the app url. We did appID**~~deis~~**.cluster.com

This approach has a problem however, because you can assign subdomains to an app that mask another app:

```console
$ deis domains:add a -a t
$ deis apps:create a --no-remote
$ deis apps:open -a a # opens a.cluster.com, which actually points to t
```

Now, `apps:open` and `apps:info` use the app's first domain, usually the one that is assigned by default. If the app doesn't have any domains, like `a` in the example does, it'll print that the app doesn't have any domains.

This also allows me to remove `api.Apps.URL` from the SDK laster, removing the naive behavior in a way that doesn't break anything.