### PR TITLE
fix(ci): build tags so that tagged commits are uploaded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 branches:
   only:
   - master
+  - /^v?(?:[0-9]+\.){2}[0-9]+.*$/
 services:
 - docker
 sudo: required
@@ -17,8 +18,6 @@ deploy:
     secure: "Z6GzxuV17FjY4s0W7SlfWQVutcj34/DNpsa3rVJn3UDKIKbSr0YxWGeISeYP4acGIueNujd30f/3/tmYLGCmswk0m4zEwaHIXZHG0MFR8LuOUjTeo6eVuPr9mMB2GrORrLifnfbi5lkpcXVEGdY9X6YTLkQLG+stsL0epoJ7HoHdMqNeNvasgpa2ZNmFBfm7qHVd69Ta2W09/wMKdo76n4qub7BBFKno9IUs1+LfsaTbE4QOsKYv4K3nUfDmHJLNMWrPW9yHFo8jTHsHnicpVzQQKvcCcPFREQljO+a4hUKEy3O6TihbfKXJ2zZBkiiylNnSbvMgp5WAzJsbddkjKz3Wi7ymAS3pWwRzdE9uVqKzbnbL4i8xSXceC1M4HPohQ/0akF75627I4N7rcqYJT+x55Eb+vGPFVBh7YYvIn58b2lFJdVXs5EYaS6SaNoi5ElWZrBpYER/wXuKSSeKhUUeJSckU+DXaJWIGzmvooAxzthPZg/ODg9OKlCDDr7minLQ06It1msKCwDHqQ1ioEMFJx7iOGyw80al0EI92T8bRG/erVCGOfzJjq9k6rRJPl3IOJRqAyX3X8PmVlZ9HeFx8U9Bm6Vtz2fEqrwQT1tchbZW8XJjygujIQbQOdBHozBbmmssn3lkIizWZ3jhYi8DUpnEPVBedePHlvKcUFI0="
   bucket: workflow-cli
   local-dir: _dist
-  on:
-    branch: master
   acl: public-read
 notifications:
   webhooks:


### PR DESCRIPTION
Right now, we have no CI builds for releases, including `v2.1`.