### PR TITLE
chore(Makefile): use latest go-dev and glide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 BUILD_OS ?=linux darwin windows
 BUILD_ARCH ?=amd64 386
 
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.10.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.14.0
 DEV_ENV_WORK_DIR := /go/src/${repo_path}
 DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_PREFIX_CGO_ENABLED := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}


### PR DESCRIPTION
See https://github.com/deis/docker-go-dev/releases/tag/0.14.0