### PR TITLE
fix(Jenkinsfile): set VERSION to git_commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,7 +121,7 @@ parallel(
 						sh 'make glideup'
 					}
 
-					sh 'make build-revision'
+					sh "VERSION=${git_commit.take(7)} make build-revision"
 
 					upload_artifacts(keyfile)
 			}


### PR DESCRIPTION
As the `checkout scm` step in the `Build artifacts` stage
may produce a different merge commit sha from the previous
`Git Info` stage (which sets `git_commit`).  Therefore, since we
are passing down `git_commit` to e2e job, we need to build artifact
with this value.

(Example of behavior can be seen in the following pipeline run https://ci.deis.io/job/Deis/job/workflow-cli/job/PR-110/17/console)

cc @Joshua-Anderson 