### PR TITLE
ref(makefile): remove GO15VENDOREXPERIMENT as it is no longer necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-export GO15VENDOREXPERIMENT=1
-
 # the filepath to this repository, relative to $GOPATH/src
 repo_path = github.com/deis/workflow-cli
 
@@ -15,8 +13,8 @@ BUILD_ARCH ?=amd64 386
 
 DEV_ENV_IMAGE := quay.io/deis/go-dev:0.14.0
 DEV_ENV_WORK_DIR := /go/src/${repo_path}
-DEV_ENV_PREFIX := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
-DEV_ENV_PREFIX_CGO_ENABLED := docker run --rm -e GO15VENDOREXPERIMENT=1 -e CGO_ENABLED=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
+DEV_ENV_PREFIX := docker run --rm -e CGO_ENABLED=0 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
+DEV_ENV_PREFIX_CGO_ENABLED := docker run --rm -e CGO_ENABLED=1 -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 DIST_DIR := _dist
 


### PR DESCRIPTION
The CLI is now built with go1.6 and docker-go-dev is using v1.6, so I don't think there's any reason to keep it around.