### PR TITLE
fix(CI): don't allow untrusted commands when uploading

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 def workpath_linux = "/src/github.com/deis/workflow-cli"
-def keyfile = "tmp/key.json"
 
 def getBasePath = { String filepath ->
 	def filename = filepath.lastIndexOf(File.separator)
@@ -15,11 +14,27 @@ def make = { String target ->
 	}
 }
 
-def upload_artifacts = { String filepath ->
+def gcs_cleanup_cmd = "sh -c 'rm -rf /.config/*'"
+def gcs_bucket = "gs://workflow-cli"
+def gcs_key = "tmp/key.json"
+
+def gcs_cmd = { String cmd ->
+	gcs_cmd = "docker run --rm -v  ${pwd()}/tmp:/.config -v ${pwd()}/_dist:/upload google/cloud-sdk:latest "
+	try {
+		sh(gcs_cmd + cmd)
+	} catch(error) {
+		sh(gcs_cmd + gcs_cleanup_cmd)
+		error 'gcs error'
+	}
+}
+
+def upload_artifacts = {
 	withCredentials([[$class: 'FileBinding', credentialsId: 'e80fd033-dd76-4d96-be79-6c272726fb82', variable: 'GCSKEY']]) {
-		sh "mkdir -p ${getBasePath(filepath)}"
-		sh "cat \"\${GCSKEY}\" > ${filepath}"
-		make 'upload-gcs'
+		sh "mkdir -p ${getBasePath(gcs_key)}"
+		sh "cat \"\${GCSKEY}\" > ${gcs_key}"
+		gcs_cmd 'gcloud auth activate-service-account -q --key-file /.config/key.json'
+		gcs_cmd "gsutil -mq cp -a public-read -r /upload/* ${gcs_bucket}"
+		gcs_cmd gcs_cleanup_cmd
 	}
 }
 
@@ -113,7 +128,7 @@ parallel(
 					env.VERSION = git_commit.take(7)
 					make 'build-revision'
 
-					upload_artifacts(keyfile)
+					upload_artifacts()
 			}
 		}
 	},
@@ -129,7 +144,7 @@ parallel(
 						make 'bootstrap'
 						make 'build-latest'
 
-						upload_artifacts(keyfile)
+						upload_artifacts()
 					} else {
 						echo "Skipping build of latest artifacts because this build is not on the master branch (branch: ${git_branch})"
 					}

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,6 @@ DEV_ENV_PREFIX_CGO_ENABLED := docker run --rm -e CGO_ENABLED=1 -v ${CURDIR}:${DE
 DEV_ENV_CMD := ${DEV_ENV_PREFIX} ${DEV_ENV_IMAGE}
 DIST_DIR := _dist
 
-GSUTIL_IMAGE := google/cloud-sdk:latest
-GSUTIL_PREFIX := docker run --rm -v  ${CURDIR}/tmp:/.config -v ${CURDIR}/${DIST_DIR}:/upload
-GSUTIL_CMD := ${GSUTIL_PREFIX} ${GSUTIL_IMAGE}
-GCS_BUCKET ?= "gs://workflow-cli"
-
 GO_FILES = $(wildcard *.go)
 GO_LDFLAGS = -ldflags "-s -X ${repo_path}/version.BuildVersion=${VERSION}"
 GO_PACKAGES = cmd parser cli $(wildcard pkg/*)
@@ -104,12 +99,6 @@ test-style:
 
 test-unit:
 	${DEV_ENV_PREFIX_CGO_ENABLED} ${DEV_ENV_IMAGE} sh -c '${GOTEST} $$(glide nv)'
-
-upload-gcs:
-	${GSUTIL_CMD} sh -c 'gcloud auth activate-service-account -q --key-file /.config/key.json'
-	${GSUTIL_CMD} sh -c 'gsutil -mq cp -a public-read -r /upload/* ${GCS_BUCKET}'
-	# This has to run in the container to delete files created by the container
-	${GSUTIL_CMD} sh -c 'rm -rf /.config/*'
 
 # Set local user as owner for files
 fileperms:


### PR DESCRIPTION
I'm not going to go into details publicly, but I realized there are ways for untrusted users to access the GCS credentials.