### PR TITLE
fix(git): fix linting error

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -30,11 +30,7 @@ func CreateRemote(host, remote, appID string) error {
 	output, _ := ioutil.ReadAll(stderr)
 	fmt.Print(string(output))
 
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return cmd.Wait()
 }
 
 // DeleteAppRemotes removes all git remotes corresponding to an app in the repository.


### PR DESCRIPTION
The `git` PR was merged at the same time as the new linting PR and somehow passed CI without running through the new linter.