### PR TITLE
fix(version): move all version logic to git

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,7 +144,7 @@ parallel(
 					}
 
 					make 'bootstrap'
-					env.VERSION = git_commit.take(7)
+					env.REVISION = git_commit.take(7)
 					make 'build-revision'
 
 					upload_artifacts()

--- a/parser/version.go
+++ b/parser/version.go
@@ -20,11 +20,7 @@ Use 'deis help [command]' to learn more.
 		return err
 	}
 
-	v := version.Version
-	if version.BuildVersion != "" {
-		v = fmt.Sprintf("%s-%s", version.Version, version.BuildVersion)
-	}
-	fmt.Println(v)
+	fmt.Println(version.Version)
 
 	return nil
 }

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -11,14 +11,12 @@ import (
 	"github.com/deis/workflow-cli/version"
 )
 
-const (
-	// UserAgent is the user agent used by the CLI
-	UserAgent = "Deis Client v" + version.Version
+// DefaultResponseLimit is the default number of responses to return on requests that can
+// be limited.
+const DefaultResponseLimit = 100
 
-	// DefaultResponseLimit is the default number of responses to return on requests that can
-	// be limited.
-	DefaultResponseLimit = 100
-)
+// UserAgent is the user agent used by the CLI
+var UserAgent = "Deis Client v" + version.Version
 
 type settingsFile struct {
 	Username   string `json:"username"`

--- a/version/version.go
+++ b/version/version.go
@@ -1,8 +1,5 @@
 package version
 
-// Version identifies this Deis product revision.
-const Version = "2.3.0"
-
-// BuildVersion is the git revision of the build.
+// Version identifies the Deis product revision.
 // Note: This value is overwritten by the linker during build
-var BuildVersion = ""
+var Version = "unknown version (override me)"


### PR DESCRIPTION
If commit is not a tagged commit: `<latest tag>-<sha>`.
If commit is tagged `<tag>`
If version is overridden with `$VERSION`, `<version>`

cc @vdice

This way we no longer have to manually bump the version in code.