### PR TITLE
feat(*): allow configuration flag

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -17,8 +17,8 @@ import (
 )
 
 // AppCreate creates an app.
-func AppCreate(id string, buildpack string, remote string, noRemote bool) error {
-	s, err := settings.Load()
+func (d DeisCmd) AppCreate(id, buildpack, remote string, noRemote bool) error {
+	s, err := settings.Load(d.ConfigFile)
 	if err != nil {
 		return err
 	}
@@ -68,8 +68,8 @@ func AppCreate(id string, buildpack string, remote string, noRemote bool) error 
 }
 
 // AppsList lists apps on the Deis controller.
-func AppsList(results int) error {
-	s, err := settings.Load()
+func (d DeisCmd) AppsList(results int) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -93,8 +93,8 @@ func AppsList(results int) error {
 }
 
 // AppInfo prints info about app.
-func AppInfo(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) AppInfo(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -124,13 +124,13 @@ func AppInfo(appID string) error {
 
 	fmt.Println()
 	// print the app processes
-	if err = PsList(app.ID, defaultLimit); err != nil {
+	if err = d.PsList(app.ID, defaultLimit); err != nil {
 		return err
 	}
 
 	fmt.Println()
 	// print the app domains
-	if err = DomainsList(app.ID, defaultLimit); err != nil {
+	if err = d.DomainsList(app.ID, defaultLimit); err != nil {
 		return err
 	}
 
@@ -140,8 +140,8 @@ func AppInfo(appID string) error {
 }
 
 // AppOpen opens an app in the default webbrowser.
-func AppOpen(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) AppOpen(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -164,8 +164,8 @@ func AppOpen(appID string) error {
 }
 
 // AppLogs returns the logs from an app.
-func AppLogs(appID string, lines int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) AppLogs(appID string, lines int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -184,8 +184,8 @@ func AppLogs(appID string, lines int) error {
 }
 
 // AppRun runs a one time command in the app.
-func AppRun(appID, command string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) AppRun(appID, command string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -209,10 +209,10 @@ func AppRun(appID, command string) error {
 }
 
 // AppDestroy destroys an app.
-func AppDestroy(appID, confirm string) error {
+func (d DeisCmd) AppDestroy(appID, confirm string) error {
 	gitSession := false
 
-	s, err := settings.Load()
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -252,15 +252,15 @@ func AppDestroy(appID, confirm string) error {
 	fmt.Printf("done in %ds\n", int(time.Since(startTime).Seconds()))
 
 	if gitSession {
-		return GitRemove(appID)
+		return d.GitRemove(appID)
 	}
 
 	return nil
 }
 
 // AppTransfer transfers app ownership to another user.
-func AppTransfer(appID, username string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) AppTransfer(appID, username string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/builds.go
+++ b/cmd/builds.go
@@ -11,8 +11,8 @@ import (
 )
 
 // BuildsList lists an app's builds.
-func BuildsList(appID string, results int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) BuildsList(appID string, results int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -36,8 +36,8 @@ func BuildsList(appID string, results int) error {
 }
 
 // BuildsCreate creates a build for an app.
-func BuildsCreate(appID, image, procfile string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) BuildsCreate(appID, image, procfile string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/certs.go
+++ b/cmd/certs.go
@@ -15,8 +15,8 @@ import (
 )
 
 // CertsList lists certs registered with the controller.
-func CertsList(results int) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertsList(results int) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -96,8 +96,8 @@ func CertsList(results int) error {
 }
 
 // CertAdd adds a cert to the controller.
-func CertAdd(cert string, key string, name string) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertAdd(cert string, key string, name string) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -133,8 +133,8 @@ func doCertAdd(c *deis.Client, cert string, key string, name string) error {
 }
 
 // CertRemove deletes a cert from the controller.
-func CertRemove(name string) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertRemove(name string) error {
+	s, err := settings.Load(d.ConfigFile)
 	if checkAPICompatibility(s.Client, err) != nil {
 		return err
 	}
@@ -154,8 +154,8 @@ func CertRemove(name string) error {
 }
 
 // CertInfo gets info about certficiate
-func CertInfo(name string) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertInfo(name string) error {
+	s, err := settings.Load(d.ConfigFile)
 	if err != nil {
 		return err
 	}
@@ -193,8 +193,8 @@ func CertInfo(name string) error {
 }
 
 // CertAttach attaches a certificate to a domain
-func CertAttach(name string, domain string) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertAttach(name, domain string) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -214,8 +214,8 @@ func CertAttach(name string, domain string) error {
 }
 
 // CertDetach detaches a certificate from a domain
-func CertDetach(name string, domain string) error {
-	s, err := settings.Load()
+func (d DeisCmd) CertDetach(name, domain string) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,76 @@
+package cmd
+
+import "github.com/deis/controller-sdk-go/api"
+
+// Commander is interface definition for running commands
+type Commander interface {
+	AppCreate(string, string, string, bool) error
+	AppsList(int) error
+	AppInfo(string) error
+	AppOpen(string) error
+	AppLogs(string, int) error
+	AppRun(string, string) error
+	AppDestroy(string, string) error
+	AppTransfer(string, string) error
+	Register(string, string, string, string, bool) error
+	Login(string, string, string, bool) error
+	Logout() error
+	Passwd(string, string, string) error
+	Cancel(string, string, bool) error
+	Whoami(bool) error
+	Regenerate(string, bool) error
+	BuildsList(string, int) error
+	BuildsCreate(string, string, string) error
+	CertsList(int) error
+	CertAdd(string, string, string) error
+	CertRemove(string) error
+	CertInfo(string) error
+	CertAttach(string, string) error
+	CertDetach(string, string) error
+	ConfigList(string, bool) error
+	ConfigSet(string, []string) error
+	ConfigUnset(string, []string) error
+	ConfigPull(string, bool, bool) error
+	ConfigPush(string, string) error
+	DomainsList(string, int) error
+	DomainsAdd(string, string) error
+	DomainsRemove(string, string) error
+	GitRemote(string, string, bool) error
+	GitRemove(string) error
+	HealthchecksList(string, string) error
+	HealthchecksSet(string, string, string, *api.Healthcheck) error
+	HealthchecksUnset(string, string, []string) error
+	KeysList(int) error
+	KeyRemove(string) error
+	KeyAdd(string) error
+	LimitsList(string) error
+	LimitsSet(string, []string, string) error
+	LimitsUnset(string, []string, string) error
+	MaintenanceInfo(string) error
+	MaintenanceEnable(string) error
+	MaintenanceDisable(string) error
+	PermsList(string, bool, int) error
+	PermCreate(string, string, bool) error
+	PermDelete(string, string, bool) error
+	PsList(string, int) error
+	PsScale(string, []string) error
+	PsRestart(string, string) error
+	RegistryList(string) error
+	RegistrySet(string, []string) error
+	RegistryUnset(string, []string) error
+	ReleasesList(string, int) error
+	ReleasesInfo(string, int) error
+	ReleasesRollback(string, int) error
+	RoutingInfo(string) error
+	RoutingEnable(string) error
+	RoutingDisable(string) error
+	TagsList(string) error
+	TagsSet(string, []string) error
+	TagsUnset(string, []string) error
+	UsersList(results int) error
+}
+
+// DeisCmd is an implementation of Commander.
+type DeisCmd struct {
+	ConfigFile string
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,8 +17,8 @@ import (
 )
 
 // ConfigList lists an app's config.
-func ConfigList(appID string, oneLine bool) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ConfigList(appID string, oneLine bool) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -57,8 +57,8 @@ func ConfigList(appID string, oneLine bool) error {
 }
 
 // ConfigSet sets an app's config variables.
-func ConfigSet(appID string, configVars []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ConfigSet(appID string, configVars []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -117,12 +117,12 @@ to set up healthchecks. This functionality has been deprecated. In the future, p
 		fmt.Print("done\n\n")
 	}
 
-	return ConfigList(appID, false)
+	return d.ConfigList(appID, false)
 }
 
 // ConfigUnset removes a config variable from an app.
-func ConfigUnset(appID string, configVars []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ConfigUnset(appID string, configVars []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -151,12 +151,12 @@ func ConfigUnset(appID string, configVars []string) error {
 
 	fmt.Print("done\n\n")
 
-	return ConfigList(appID, false)
+	return d.ConfigList(appID, false)
 }
 
 // ConfigPull pulls an app's config to a file.
-func ConfigPull(appID string, interactive bool, overwrite bool) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ConfigPull(appID string, interactive bool, overwrite bool) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -222,7 +222,7 @@ func ConfigPull(appID string, interactive bool, overwrite bool) error {
 }
 
 // ConfigPush pushes an app's config from a file.
-func ConfigPush(appID, fileName string) error {
+func (d DeisCmd) ConfigPush(appID, fileName string) error {
 	stat, err := os.Stdin.Stat()
 
 	if err != nil {
@@ -252,7 +252,7 @@ func ConfigPush(appID, fileName string) error {
 		}
 	}
 
-	return ConfigSet(appID, config)
+	return d.ConfigSet(appID, config)
 }
 
 func parseConfig(configVars []string) map[string]interface{} {

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -7,8 +7,8 @@ import (
 )
 
 // DomainsList lists domains registered with an app.
-func DomainsList(appID string, results int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) DomainsList(appID string, results int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -32,8 +32,8 @@ func DomainsList(appID string, results int) error {
 }
 
 // DomainsAdd adds a domain to an app.
-func DomainsAdd(appID, domain string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) DomainsAdd(appID, domain string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -54,8 +54,8 @@ func DomainsAdd(appID, domain string) error {
 }
 
 // DomainsRemove removes a domain registered with an app.
-func DomainsRemove(appID, domain string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) DomainsRemove(appID, domain string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -10,8 +10,8 @@ const remoteCreationMsg = "Git remote %s successfully created for app %s.\n"
 const remoteDeletionMsg = "Git remotes for app %s removed.\n"
 
 // GitRemote creates a git remote for a deis app.
-func GitRemote(appID string, remote string, force bool) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) GitRemote(appID, remote string, force bool) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	remoteURL, err := git.RemoteValue(remote)
 
@@ -49,8 +49,8 @@ func GitRemote(appID string, remote string, force bool) error {
 }
 
 // GitRemove removes a application git remote from a repository
-func GitRemove(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) GitRemove(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/healthchecks.go
+++ b/cmd/healthchecks.go
@@ -26,9 +26,8 @@ func printHealthCheck(out io.Writer, healthcheck api.Healthchecks) {
 }
 
 // HealthchecksList lists an app's healthchecks.
-func HealthchecksList(appID, procType string) error {
-	s, appID, err := load(appID)
-
+func (d DeisCmd) HealthchecksList(appID, procType string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 	if err != nil {
 		return err
 	}
@@ -51,8 +50,8 @@ func HealthchecksList(appID, procType string) error {
 }
 
 // HealthchecksSet sets an app's healthchecks.
-func HealthchecksSet(appID, healthcheckType, procType string, probe *api.Healthcheck) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) HealthchecksSet(appID, healthcheckType, procType string, probe *api.Healthcheck) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -78,13 +77,12 @@ func HealthchecksSet(appID, healthcheckType, procType string, probe *api.Healthc
 
 	fmt.Print("done\n\n")
 
-	return HealthchecksList(appID, procType)
+	return d.HealthchecksList(appID, procType)
 }
 
 // HealthchecksUnset removes an app's healthchecks.
-func HealthchecksUnset(appID, procType string, healthchecks []string) error {
-	s, appID, err := load(appID)
-
+func (d DeisCmd) HealthchecksUnset(appID, procType string, healthchecks []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 	if err != nil {
 		return err
 	}
@@ -116,5 +114,5 @@ func HealthchecksUnset(appID, procType string, healthchecks []string) error {
 
 	fmt.Print("done\n\n")
 
-	return HealthchecksList(appID, procType)
+	return d.HealthchecksList(appID, procType)
 }

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -16,8 +16,8 @@ import (
 )
 
 // KeysList lists a user's keys.
-func KeysList(results int) error {
-	s, err := settings.Load()
+func (d DeisCmd) KeysList(results int) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -41,8 +41,8 @@ func KeysList(results int) error {
 }
 
 // KeyRemove removes keys.
-func KeyRemove(keyID string) error {
-	s, err := settings.Load()
+func (d DeisCmd) KeyRemove(keyID string) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err
@@ -60,8 +60,8 @@ func KeyRemove(keyID string) error {
 }
 
 // KeyAdd adds keys.
-func KeyAdd(keyLocation string) error {
-	s, err := settings.Load()
+func (d DeisCmd) KeyAdd(keyLocation string) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err

--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -11,8 +11,8 @@ import (
 )
 
 // LimitsList lists an app's limits.
-func LimitsList(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) LimitsList(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -55,8 +55,8 @@ func LimitsList(appID string) error {
 }
 
 // LimitsSet sets an app's limits.
-func LimitsSet(appID string, limits []string, limitType string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) LimitsSet(appID string, limits []string, limitType string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -87,12 +87,12 @@ func LimitsSet(appID string, limits []string, limitType string) error {
 
 	fmt.Print("done\n\n")
 
-	return LimitsList(appID)
+	return d.LimitsList(appID)
 }
 
 // LimitsUnset removes an app's limits.
-func LimitsUnset(appID string, limits []string, limitType string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) LimitsUnset(appID string, limits []string, limitType string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func LimitsUnset(appID string, limits []string, limitType string) error {
 
 	fmt.Print("done\n\n")
 
-	return LimitsList(appID)
+	return d.LimitsList(appID)
 }
 
 func parseLimits(limits []string) (map[string]interface{}, error) {

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -8,8 +8,8 @@ import (
 )
 
 // MaintenanceInfo tells the informations about app's maintenance status
-func MaintenanceInfo(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) MaintenanceInfo(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -29,8 +29,8 @@ func MaintenanceInfo(appID string) error {
 }
 
 // MaintenanceEnable turns on the maintenance for the app.
-func MaintenanceEnable(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) MaintenanceEnable(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -54,8 +54,8 @@ func MaintenanceEnable(appID string) error {
 }
 
 // MaintenanceDisable turns off the maintenance for the app.
-func MaintenanceDisable(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) MaintenanceDisable(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/perms.go
+++ b/cmd/perms.go
@@ -9,8 +9,8 @@ import (
 )
 
 // PermsList prints which users have permissions.
-func PermsList(appID string, admin bool, results int) error {
-	s, appID, err := permsLoad(appID, admin)
+func (d DeisCmd) PermsList(appID string, admin bool, results int) error {
+	s, appID, err := permsLoad(d.ConfigFile, appID, admin)
 
 	if err != nil {
 		return err
@@ -46,9 +46,9 @@ func PermsList(appID string, admin bool, results int) error {
 }
 
 // PermCreate adds a user to an app or makes them an administrator.
-func PermCreate(appID string, username string, admin bool) error {
+func (d DeisCmd) PermCreate(appID string, username string, admin bool) error {
 
-	s, appID, err := permsLoad(appID, admin)
+	s, appID, err := permsLoad(d.ConfigFile, appID, admin)
 
 	if err != nil {
 		return err
@@ -72,9 +72,9 @@ func PermCreate(appID string, username string, admin bool) error {
 }
 
 // PermDelete removes a user from an app or revokes admin privileges.
-func PermDelete(appID string, username string, admin bool) error {
+func (d DeisCmd) PermDelete(appID, username string, admin bool) error {
 
-	s, appID, err := permsLoad(appID, admin)
+	s, appID, err := permsLoad(d.ConfigFile, appID, admin)
 
 	if err != nil {
 		return err
@@ -97,8 +97,8 @@ func PermDelete(appID string, username string, admin bool) error {
 	return nil
 }
 
-func permsLoad(appID string, admin bool) (*settings.Settings, string, error) {
-	s, err := settings.Load()
+func permsLoad(cf, appID string, admin bool) (*settings.Settings, string, error) {
+	s, err := settings.Load(cf)
 
 	if err != nil {
 		return nil, "", err

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -13,8 +13,8 @@ import (
 )
 
 // PsList lists an app's processes.
-func PsList(appID string, results int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) PsList(appID string, results int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 	if err != nil {
 		return err
 	}
@@ -34,8 +34,8 @@ func PsList(appID string, results int) error {
 }
 
 // PsScale scales an app's processes.
-func PsScale(appID string, targets []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) PsScale(appID string, targets []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -80,8 +80,8 @@ func PsScale(appID string, targets []string) error {
 }
 
 // PsRestart restarts an app's processes.
-func PsRestart(appID, target string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) PsRestart(appID, target string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/ps_test.go
+++ b/cmd/ps_test.go
@@ -1,26 +1,25 @@
 package cmd
 
 import (
-	"github.com/deis/workflow-cli/settings"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 )
 
 func TestScaleFail(t *testing.T) {
+	t.Parallel()
+
 	tmpDir, err := ioutil.TempDir("", "tmpdir")
 	if err != nil {
 		t.Fatalf("error creating temp directory (%s)", err)
 	}
-	err = os.Mkdir(tmpDir+"/.deis", 0666)
-	if err != nil {
-		t.Fatalf("error creating temp directory (%s)", err)
-	}
-	os.Setenv("DEIS_PROFILE", "testing")
-	settings.SetHome(tmpDir)
+
+	file := filepath.Join(tmpDir, "client.json")
+
 	data := []byte(`{"username":"test","ssl_verify":false,"controller":"http://deis.127.0.0.1.nip.io","token":"test","response_limit":0}`)
-	if err := ioutil.WriteFile(tmpDir+"/.deis/testing.json", data, 0644); err != nil {
-		t.Fatalf("error creating %s/.deis/testing.json (%s)", tmpDir, err)
+	if err := ioutil.WriteFile(file, data, 0644); err != nil {
+		t.Fatal("error creating config file")
 	}
 	defer func() {
 		if err := os.RemoveAll(tmpDir); err != nil {
@@ -29,7 +28,8 @@ func TestScaleFail(t *testing.T) {
 	}()
 
 	expected := "'web=-1' does not match the pattern 'type=num', ex: web=2\n"
-	actual := PsScale("testApp", []string{"web=-1"})
+	d := DeisCmd{ConfigFile: file}
+	actual := d.PsScale("testApp", []string{"web=-1"})
 	if actual.Error() != expected {
 		t.Errorf("Expected %s, Got %s", expected, actual)
 	}

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -11,8 +11,8 @@ import (
 )
 
 // RegistryList lists an app's registry information.
-func RegistryList(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) RegistryList(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -37,8 +37,8 @@ func RegistryList(appID string) error {
 }
 
 // RegistrySet sets an app's registry information.
-func RegistrySet(appID string, item []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) RegistrySet(appID string, item []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -61,12 +61,12 @@ func RegistrySet(appID string, item []string) error {
 
 	fmt.Print("done\n\n")
 
-	return RegistryList(appID)
+	return d.RegistryList(appID)
 }
 
 // RegistryUnset removes an app's registry information.
-func RegistryUnset(appID string, items []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) RegistryUnset(appID string, items []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func RegistryUnset(appID string, items []string) error {
 
 	fmt.Print("done\n\n")
 
-	return RegistryList(appID)
+	return d.RegistryList(appID)
 }
 
 func parseInfos(items []string) map[string]interface{} {

--- a/cmd/releases.go
+++ b/cmd/releases.go
@@ -9,8 +9,8 @@ import (
 )
 
 // ReleasesList lists an app's releases.
-func ReleasesList(appID string, results int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ReleasesList(appID string, results int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -38,8 +38,8 @@ func ReleasesList(appID string, results int) error {
 }
 
 // ReleasesInfo prints info about a specific release.
-func ReleasesInfo(appID string, version int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ReleasesInfo(appID string, version int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -65,8 +65,8 @@ func ReleasesInfo(appID string, version int) error {
 }
 
 // ReleasesRollback rolls an app back to a previous release.
-func ReleasesRollback(appID string, version int) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) ReleasesRollback(appID string, version int) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/routing.go
+++ b/cmd/routing.go
@@ -7,8 +7,9 @@ import (
 	"github.com/deis/controller-sdk-go/appsettings"
 )
 
-func RoutingInfo(appID string) error {
-	s, appID, err := load(appID)
+// RoutingInfo provides information about the status of app routing.
+func (d DeisCmd) RoutingInfo(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -28,8 +29,8 @@ func RoutingInfo(appID string) error {
 }
 
 // RoutingEnable enables an app from being exposed by the router.
-func RoutingEnable(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) RoutingEnable(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -53,8 +54,8 @@ func RoutingEnable(appID string) error {
 }
 
 // RoutingDisable disables an app from being exposed by the router.
-func RoutingDisable(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) RoutingDisable(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -11,8 +11,8 @@ import (
 )
 
 // TagsList lists an app's tags.
-func TagsList(appID string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) TagsList(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -37,8 +37,8 @@ func TagsList(appID string) error {
 }
 
 // TagsSet sets an app's tags.
-func TagsSet(appID string, tags []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) TagsSet(appID string, tags []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -61,12 +61,12 @@ func TagsSet(appID string, tags []string) error {
 
 	fmt.Print("done\n\n")
 
-	return TagsList(appID)
+	return d.TagsList(appID)
 }
 
 // TagsUnset removes an app's tags.
-func TagsUnset(appID string, tags []string) error {
-	s, appID, err := load(appID)
+func (d DeisCmd) TagsUnset(appID string, tags []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func TagsUnset(appID string, tags []string) error {
 
 	fmt.Print("done\n\n")
 
-	return TagsList(appID)
+	return d.TagsList(appID)
 }
 
 func parseTags(tags []string) map[string]interface{} {

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -8,8 +8,8 @@ import (
 )
 
 // UsersList lists users registered with the controller.
-func UsersList(results int) error {
-	s, err := settings.Load()
+func (d DeisCmd) UsersList(results int) error {
+	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
 		return err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -37,8 +37,8 @@ func progress() chan bool {
 }
 
 // load loads settings file and looks up the app name
-func load(appID string) (*settings.Settings, string, error) {
-	s, err := settings.Load()
+func load(cf string, appID string) (*settings.Settings, string, error) {
+	s, err := settings.Load(cf)
 
 	if err != nil {
 		return nil, "", err

--- a/parser/apps.go
+++ b/parser/apps.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Apps routes app commands to their specific function.
-func Apps(argv []string) error {
+func Apps(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for apps:
 
@@ -27,21 +27,21 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "apps:create":
-		return appCreate(argv)
+		return appCreate(argv, cmdr)
 	case "apps:list":
-		return appsList(argv)
+		return appsList(argv, cmdr)
 	case "apps:info":
-		return appInfo(argv)
+		return appInfo(argv, cmdr)
 	case "apps:open":
-		return appOpen(argv)
+		return appOpen(argv, cmdr)
 	case "apps:logs":
-		return appLogs(argv)
+		return appLogs(argv, cmdr)
 	case "apps:run":
-		return appRun(argv)
+		return appRun(argv, cmdr)
 	case "apps:destroy":
-		return appDestroy(argv)
+		return appDestroy(argv, cmdr)
 	case "apps:transfer":
-		return appTransfer(argv)
+		return appTransfer(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -49,7 +49,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "apps" {
 			argv[0] = "apps:list"
-			return appsList(argv)
+			return appsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -57,7 +57,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func appCreate(argv []string) error {
+func appCreate(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Creates a new application.
 
@@ -78,6 +78,7 @@ Options:
   -r --remote REMOTE
     name of remote to create. [default: deis]
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -89,10 +90,10 @@ Options:
 	remote := safeGetValue(args, "--remote")
 	noRemote := args["--no-remote"].(bool)
 
-	return cmd.AppCreate(id, buildpack, remote, noRemote)
+	return cmdr.AppCreate(id, buildpack, remote, noRemote)
 }
 
-func appsList(argv []string) error {
+func appsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists applications visible to the current user.
 
@@ -102,6 +103,7 @@ Options:
   -l --limit=<num>
     the maximum number of results to display, defaults to config setting
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -114,10 +116,10 @@ Options:
 		return err
 	}
 
-	return cmd.AppsList(results)
+	return cmdr.AppsList(results)
 }
 
-func appInfo(argv []string) error {
+func appInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application.
 
@@ -127,6 +129,7 @@ Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -135,10 +138,10 @@ Options:
 
 	app := safeGetValue(args, "--app")
 
-	return cmd.AppInfo(app)
+	return cmdr.AppInfo(app)
 }
 
-func appOpen(argv []string) error {
+func appOpen(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Opens a URL to the application in the default browser.
 
@@ -148,6 +151,7 @@ Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -156,10 +160,10 @@ Options:
 
 	app := safeGetValue(args, "--app")
 
-	return cmd.AppOpen(app)
+	return cmdr.AppOpen(app)
 }
 
-func appLogs(argv []string) error {
+func appLogs(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Retrieves the most recent log events.
 
@@ -171,6 +175,7 @@ Options:
   -n --lines=<lines>
     the number of lines to display
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -192,10 +197,10 @@ Options:
 		}
 	}
 
-	return cmd.AppLogs(app, lines)
+	return cmdr.AppLogs(app, lines)
 }
 
-func appRun(argv []string) error {
+func appRun(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Runs a command inside an ephemeral app container. Default environment is
 /bin/bash.
@@ -210,6 +215,7 @@ Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -219,10 +225,10 @@ Options:
 	app := safeGetValue(args, "--app")
 	command := strings.Join(args["<command>"].([]string), " ")
 
-	return cmd.AppRun(app, command)
+	return cmdr.AppRun(app, command)
 }
 
-func appDestroy(argv []string) error {
+func appDestroy(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Destroys an application.
 
@@ -234,8 +240,8 @@ Options:
   --confirm=<app>
     skips the prompt for the application name. <app> is the uniquely identifiable
     name for the application.
-
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -245,10 +251,10 @@ Options:
 	app := safeGetValue(args, "--app")
 	confirm := safeGetValue(args, "--confirm")
 
-	return cmd.AppDestroy(app, confirm)
+	return cmdr.AppDestroy(app, confirm)
 }
 
-func appTransfer(argv []string) error {
+func appTransfer(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Transfer app ownership to another user.
 
@@ -262,11 +268,15 @@ Options:
   -a --app=<app>
     the uniquely identifiable name for the application.
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
 		return err
 	}
 
-	return cmd.AppTransfer(safeGetValue(args, "--app"), safeGetValue(args, "<username>"))
+	app := safeGetValue(args, "--app")
+	user := safeGetValue(args, "<username>")
+
+	return cmdr.AppTransfer(app, user)
 }

--- a/parser/auth.go
+++ b/parser/auth.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Auth routes auth commands to the specific function.
-func Auth(argv []string) error {
+func Auth(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for auth:
 
@@ -25,19 +25,19 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "auth:register":
-		return authRegister(argv)
+		return authRegister(argv, cmdr)
 	case "auth:login":
-		return authLogin(argv)
+		return authLogin(argv, cmdr)
 	case "auth:logout":
-		return authLogout(argv)
+		return authLogout(argv, cmdr)
 	case "auth:passwd":
-		return authPasswd(argv)
+		return authPasswd(argv, cmdr)
 	case "auth:whoami":
-		return authWhoami(argv)
+		return authWhoami(argv, cmdr)
 	case "auth:cancel":
-		return authCancel(argv)
+		return authCancel(argv, cmdr)
 	case "auth:regenerate":
-		return authRegenerate(argv)
+		return authRegenerate(argv, cmdr)
 	case "auth":
 		fmt.Print(usage)
 		return nil
@@ -47,7 +47,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func authRegister(argv []string) error {
+func authRegister(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Registers a new user with a Deis controller.
 
@@ -67,6 +67,7 @@ Options:
   --ssl-verify=false
     disables SSL certificate verification for API requests
 `
+
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
 	if err != nil {
@@ -83,10 +84,10 @@ Options:
 		sslVerify = true
 	}
 
-	return cmd.Register(controller, username, password, email, sslVerify)
+	return cmdr.Register(controller, username, password, email, sslVerify)
 }
 
-func authLogin(argv []string) error {
+func authLogin(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Logs in by authenticating against a controller.
 
@@ -120,24 +121,26 @@ Options:
 		sslVerify = true
 	}
 
-	return cmd.Login(controller, username, password, sslVerify)
+	return cmdr.Login(controller, username, password, sslVerify)
 }
 
-func authLogout(argv []string) error {
+func authLogout(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Logs out from a controller and clears the user session.
 
 Usage: deis auth:logout
+
+Options:
 `
 
 	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
 		return err
 	}
 
-	return cmd.Logout()
+	return cmdr.Logout()
 }
 
-func authPasswd(argv []string) error {
+func authPasswd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Changes the password for the current user.
 
@@ -162,10 +165,10 @@ Options:
 	password := safeGetValue(args, "--password")
 	newPassword := safeGetValue(args, "--new-password")
 
-	return cmd.Passwd(username, password, newPassword)
+	return cmdr.Passwd(username, password, newPassword)
 }
 
-func authWhoami(argv []string) error {
+func authWhoami(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Displays the currently logged in user.
 
@@ -182,10 +185,10 @@ Options:
 		return err
 	}
 
-	return cmd.Whoami(args["--all"].(bool))
+	return cmdr.Whoami(args["--all"].(bool))
 }
 
-func authCancel(argv []string) error {
+func authCancel(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Cancels and removes the current account.
 
@@ -210,10 +213,10 @@ Options:
 	password := safeGetValue(args, "--password")
 	yes := args["--yes"].(bool)
 
-	return cmd.Cancel(username, password, yes)
+	return cmdr.Cancel(username, password, yes)
 }
 
-func authRegenerate(argv []string) error {
+func authRegenerate(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Regenerates auth token, defaults to regenerating token for the current user.
 
@@ -235,5 +238,5 @@ Options:
 	username := safeGetValue(args, "--username")
 	all := args["--all"].(bool)
 
-	return cmd.Regenerate(username, all)
+	return cmdr.Regenerate(username, all)
 }

--- a/parser/builds.go
+++ b/parser/builds.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Builds routes build commands to their specific function.
-func Builds(argv []string) error {
+func Builds(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for builds:
 
@@ -18,9 +18,9 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "builds:list":
-		return buildsList(argv)
+		return buildsList(argv, cmdr)
 	case "builds:create":
-		return buildsCreate(argv)
+		return buildsCreate(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -28,7 +28,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "builds" {
 			argv[0] = "builds:list"
-			return buildsList(argv)
+			return buildsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -36,7 +36,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func buildsList(argv []string) error {
+func buildsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists build history for an application.
 
@@ -61,10 +61,10 @@ Options:
 		return err
 	}
 
-	return cmd.BuildsList(safeGetValue(args, "--app"), results)
+	return cmdr.BuildsList(safeGetValue(args, "--app"), results)
 }
 
-func buildsCreate(argv []string) error {
+func buildsCreate(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Creates a new build of an application. Imports an <image> and deploys it to Deis
 as a new release. If a Procfile is present in the current directory, it will be used
@@ -95,5 +95,5 @@ Options:
 	image := safeGetValue(args, "<image>")
 	procfile := safeGetValue(args, "--procfile")
 
-	return cmd.BuildsCreate(app, image, procfile)
+	return cmdr.BuildsCreate(app, image, procfile)
 }

--- a/parser/certs.go
+++ b/parser/certs.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Certs routes certs commands to their specific function.
-func Certs(argv []string) error {
+func Certs(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for certs:
 
@@ -22,17 +22,17 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "certs:list":
-		return certsList(argv)
+		return certsList(argv, cmdr)
 	case "certs:add":
-		return certAdd(argv)
+		return certAdd(argv, cmdr)
 	case "certs:remove":
-		return certRemove(argv)
+		return certRemove(argv, cmdr)
 	case "certs:info":
-		return certInfo(argv)
+		return certInfo(argv, cmdr)
 	case "certs:attach":
-		return certAttach(argv)
+		return certAttach(argv, cmdr)
 	case "certs:detach":
-		return certDetach(argv)
+		return certDetach(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -40,7 +40,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "certs" {
 			argv[0] = "certs:list"
-			return certsList(argv)
+			return certsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -48,7 +48,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func certsList(argv []string) error {
+func certsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Show certificate information for an SSL application.
 
@@ -69,10 +69,10 @@ Options:
 		return err
 	}
 
-	return cmd.CertsList(results)
+	return cmdr.CertsList(results)
 }
 
-func certAdd(argv []string) error {
+func certAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Binds a certificate/key pair to an application.
 
@@ -85,6 +85,8 @@ Arguments:
     The public key of the SSL certificate.
   <key>
     The private key of the SSL certificate.
+
+Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -96,10 +98,10 @@ Arguments:
 	cert := args["<cert>"].(string)
 	key := args["<key>"].(string)
 
-	return cmd.CertAdd(cert, key, name)
+	return cmdr.CertAdd(cert, key, name)
 }
 
-func certRemove(argv []string) error {
+func certRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 removes a certificate/key pair from the application.
 
@@ -108,6 +110,8 @@ Usage: deis certs:remove <name> [options]
 Arguments:
   <name>
     the name of the cert to remove from the app.
+
+Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -115,10 +119,10 @@ Arguments:
 		return err
 	}
 
-	return cmd.CertRemove(safeGetValue(args, "<name>"))
+	return cmdr.CertRemove(safeGetValue(args, "<name>"))
 }
 
-func certInfo(argv []string) error {
+func certInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 fetch more detailed information about a certificate
 
@@ -127,6 +131,8 @@ Usage: deis certs:info <name> [options]
 Arguments:
   <name>
     the name of the cert to get information from
+
+Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -134,10 +140,10 @@ Arguments:
 		return err
 	}
 
-	return cmd.CertInfo(safeGetValue(args, "<name>"))
+	return cmdr.CertInfo(safeGetValue(args, "<name>"))
 }
 
-func certAttach(argv []string) error {
+func certAttach(argv []string, cmdr cmd.Commander) error {
 	usage := `
 attach a certificate to a domain.
 
@@ -148,6 +154,8 @@ Arguments:
     name of the certificate to attach domain to
   <domain>
     common name of the domain to attach to (needs to already be in the system)
+
+Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -157,10 +165,10 @@ Arguments:
 
 	name := safeGetValue(args, "<name>")
 	domain := safeGetValue(args, "<domain>")
-	return cmd.CertAttach(name, domain)
+	return cmdr.CertAttach(name, domain)
 }
 
-func certDetach(argv []string) error {
+func certDetach(argv []string, cmdr cmd.Commander) error {
 	usage := `
 detach a certificate from a domain.
 
@@ -171,6 +179,8 @@ Arguments:
     name of the certificate to deatch from a domain
   <domain>
     common name of the domain to detach from
+
+Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
@@ -180,5 +190,5 @@ Arguments:
 
 	name := safeGetValue(args, "<name>")
 	domain := safeGetValue(args, "<domain>")
-	return cmd.CertDetach(name, domain)
+	return cmdr.CertDetach(name, domain)
 }

--- a/parser/config.go
+++ b/parser/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Config routes config commands to their specific function.
-func Config(argv []string) error {
+func Config(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for config:
 
@@ -21,15 +21,15 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "config:list":
-		return configList(argv)
+		return configList(argv, cmdr)
 	case "config:set":
-		return configSet(argv)
+		return configSet(argv, cmdr)
 	case "config:unset":
-		return configUnset(argv)
+		return configUnset(argv, cmdr)
 	case "config:pull":
-		return configPull(argv)
+		return configPull(argv, cmdr)
 	case "config:push":
-		return configPush(argv)
+		return configPush(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -37,7 +37,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "config" {
 			argv[0] = "config:list"
-			return configList(argv)
+			return configList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -45,7 +45,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func configList(argv []string) error {
+func configList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists environment variables for an application.
 
@@ -63,11 +63,13 @@ Options:
 	if err != nil {
 		return err
 	}
+	app := safeGetValue(args, "--app")
+	oneline := args["--oneline"].(bool)
 
-	return cmd.ConfigList(safeGetValue(args, "--app"), args["--oneline"].(bool))
+	return cmdr.ConfigList(app, oneline)
 }
 
-func configSet(argv []string) error {
+func configSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets environment variables for an application.
 
@@ -90,10 +92,12 @@ Options:
 		return err
 	}
 
-	return cmd.ConfigSet(safeGetValue(args, "--app"), args["<var>=<value>"].([]string))
+	app := safeGetValue(args, "--app")
+
+	return cmdr.ConfigSet(app, args["<var>=<value>"].([]string))
 }
 
-func configUnset(argv []string) error {
+func configUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets an environment variable for an application.
 
@@ -113,11 +117,12 @@ Options:
 	if err != nil {
 		return err
 	}
+	app := safeGetValue(args, "--app")
 
-	return cmd.ConfigUnset(safeGetValue(args, "--app"), args["<key>"].([]string))
+	return cmdr.ConfigUnset(app, args["<key>"].([]string))
 }
 
-func configPull(argv []string) error {
+func configPull(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Extract all environment variables from an application for local use.
 
@@ -146,10 +151,10 @@ Options:
 	interactive := args["--interactive"].(bool)
 	overwrite := args["--overwrite"].(bool)
 
-	return cmd.ConfigPull(app, interactive, overwrite)
+	return cmdr.ConfigPull(app, interactive, overwrite)
 }
 
-func configPush(argv []string) error {
+func configPush(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets environment variables for an application.
 
@@ -172,5 +177,8 @@ Options:
 		return err
 	}
 
-	return cmd.ConfigPush(safeGetValue(args, "--app"), safeGetValue(args, "--path"))
+	app := safeGetValue(args, "--app")
+	path := safeGetValue(args, "--path")
+
+	return cmdr.ConfigPush(app, path)
 }

--- a/parser/domains.go
+++ b/parser/domains.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Domains routes domain commands to their specific function.
-func Domains(argv []string) error {
+func Domains(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for domains:
 
@@ -16,13 +16,14 @@ domains:remove        unbind a domain from an application
 
 Use 'deis help [command]' to learn more.
 `
+
 	switch argv[0] {
 	case "domains:add":
-		return domainsAdd(argv)
+		return domainsAdd(argv, cmdr)
 	case "domains:list":
-		return domainsList(argv)
+		return domainsList(argv, cmdr)
 	case "domains:remove":
-		return domainsRemove(argv)
+		return domainsRemove(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -30,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "domains" {
 			argv[0] = "domains:list"
-			return domainsList(argv)
+			return domainsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -38,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func domainsAdd(argv []string) error {
+func domainsAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Binds a domain to an application.
 
@@ -59,10 +60,13 @@ Options:
 		return err
 	}
 
-	return cmd.DomainsAdd(safeGetValue(args, "--app"), safeGetValue(args, "<domain>"))
+	app := safeGetValue(args, "--app")
+	domain := safeGetValue(args, "<domain>")
+
+	return cmdr.DomainsAdd(app, domain)
 }
 
-func domainsList(argv []string) error {
+func domainsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists domains bound to an application.
 
@@ -86,11 +90,12 @@ Options:
 	if err != nil {
 		return err
 	}
+	app := safeGetValue(args, "--app")
 
-	return cmd.DomainsList(safeGetValue(args, "--app"), results)
+	return cmdr.DomainsList(app, results)
 }
 
-func domainsRemove(argv []string) error {
+func domainsRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unbinds a domain for an application.
 
@@ -111,5 +116,8 @@ Options:
 		return err
 	}
 
-	return cmd.DomainsRemove(safeGetValue(args, "--app"), safeGetValue(args, "<domain>"))
+	app := safeGetValue(args, "--app")
+	domain := safeGetValue(args, "<domain>")
+
+	return cmdr.DomainsRemove(app, domain)
 }

--- a/parser/git.go
+++ b/parser/git.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Git routes git commands to their specific function.
-func Git(argv []string) error {
+func Git(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for git:
 
@@ -20,9 +20,9 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "git:remote":
-		return gitRemote(argv)
+		return gitRemote(argv, cmdr)
 	case "git:remove":
-		return gitRemove(argv)
+		return gitRemove(argv, cmdr)
 	case "git":
 		fmt.Print(usage)
 		return nil
@@ -32,7 +32,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func gitRemote(argv []string) error {
+func gitRemote(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds git remote of application to repository
 
@@ -53,10 +53,14 @@ Options:
 		return err
 	}
 
-	return cmd.GitRemote(safeGetValue(args, "--app"), args["--remote"].(string), args["--force"].(bool))
+	app := safeGetValue(args, "--app")
+	remote := safeGetValue(args, "--remote")
+	force := args["--force"].(bool)
+
+	return cmdr.GitRemote(app, remote, force)
 }
 
-func gitRemove(argv []string) error {
+func gitRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Removes git remotes of application from repository.
 
@@ -73,5 +77,5 @@ Options:
 		return err
 	}
 
-	return cmd.GitRemove(safeGetValue(args, "--app"))
+	return cmdr.GitRemove(safeGetValue(args, "--app"))
 }

--- a/parser/healthchecks.go
+++ b/parser/healthchecks.go
@@ -18,7 +18,7 @@ const (
 )
 
 // Healthchecks routes ealthcheck commands to their specific function
-func Healthchecks(argv []string) error {
+func Healthchecks(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for healthchecks:
 
@@ -31,11 +31,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "healthchecks:list":
-		return healthchecksList(argv)
+		return healthchecksList(argv, cmdr)
 	case "healthchecks:set":
-		return healthchecksSet(argv)
+		return healthchecksSet(argv, cmdr)
 	case "healthchecks:unset":
-		return healthchecksUnset(argv)
+		return healthchecksUnset(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -43,7 +43,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "healthchecks" {
 			argv[0] = "healthchecks:list"
-			return healthchecksList(argv)
+			return healthchecksList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -51,7 +51,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func healthchecksList(argv []string) error {
+func healthchecksList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists healthchecks for an application.
 
@@ -76,10 +76,10 @@ Options:
 		procType = defaultProcType
 	}
 
-	return cmd.HealthchecksList(app, procType)
+	return cmdr.HealthchecksList(app, procType)
 }
 
-func healthchecksSet(argv []string) error {
+func healthchecksSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets healthchecks for an application.
 
@@ -213,10 +213,11 @@ Options:
 	default:
 		return fmt.Errorf("Invalid probe type. Must be one of: \"httpGet\", \"exec\"")
 	}
-	return cmd.HealthchecksSet(app, healthcheckType, procType, probe)
+
+	return cmdr.HealthchecksSet(app, healthcheckType, procType, probe)
 }
 
-func healthchecksUnset(argv []string) error {
+func healthchecksUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets healthchecks for an application.
 
@@ -252,7 +253,7 @@ Options:
 		healthchecks[healthcheck] += "Probe"
 	}
 
-	return cmd.HealthchecksUnset(app, procType, healthchecks)
+	return cmdr.HealthchecksUnset(app, procType, healthchecks)
 }
 
 func parseHeaders(headers []string) ([]*api.KVPair, error) {

--- a/parser/keys.go
+++ b/parser/keys.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Keys routes key commands to the specific function.
-func Keys(argv []string) error {
+func Keys(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for SSH keys:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "keys:list":
-		return keysList(argv)
+		return keysList(argv, cmdr)
 	case "keys:add":
-		return keyAdd(argv)
+		return keyAdd(argv, cmdr)
 	case "keys:remove":
-		return keyRemove(argv)
+		return keyRemove(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "keys" {
 			argv[0] = "keys:list"
-			return keysList(argv)
+			return keysList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func keysList(argv []string) error {
+func keysList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists SSH keys for the logged in user.
 
@@ -62,10 +62,10 @@ Options:
 		return err
 	}
 
-	return cmd.KeysList(results)
+	return cmdr.KeysList(results)
 }
 
-func keyAdd(argv []string) error {
+func keyAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds SSH keys for the logged in user.
 
@@ -77,17 +77,14 @@ Arguments:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
-	key := safeGetValue(args, "<key>")
-
-	return cmd.KeyAdd(key)
+	return cmdr.KeyAdd(safeGetValue(args, "<key>"))
 }
 
-func keyRemove(argv []string) error {
+func keyRemove(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Removes an SSH key for the logged in user.
 
@@ -99,12 +96,9 @@ Arguments:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
-	key := safeGetValue(args, "<key>")
-
-	return cmd.KeyRemove(key)
+	return cmdr.KeyRemove(safeGetValue(args, "<key>"))
 }

--- a/parser/limits.go
+++ b/parser/limits.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Limits routes limits commands to their specific function
-func Limits(argv []string) error {
+func Limits(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for limits:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "limits:list":
-		return limitsList(argv)
+		return limitsList(argv, cmdr)
 	case "limits:set":
-		return limitSet(argv)
+		return limitSet(argv, cmdr)
 	case "limits:unset":
-		return limitUnset(argv)
+		return limitUnset(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "limits" {
 			argv[0] = "limits:list"
-			return limitsList(argv)
+			return limitsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func limitsList(argv []string) error {
+func limitsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists resource limits for an application.
 
@@ -56,10 +56,10 @@ Options:
 		return err
 	}
 
-	return cmd.LimitsList(safeGetValue(args, "--app"))
+	return cmdr.LimitsList(safeGetValue(args, "--app"))
 }
 
-func limitSet(argv []string) error {
+func limitSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets resource limits for an application.
 
@@ -111,10 +111,10 @@ Options:
 		limitType = "cpu"
 	}
 
-	return cmd.LimitsSet(app, limits, limitType)
+	return cmdr.LimitsSet(app, limits, limitType)
 }
 
-func limitUnset(argv []string) error {
+func limitUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets resource limits for an application.
 
@@ -148,5 +148,5 @@ Options:
 		limitType = "cpu"
 	}
 
-	return cmd.LimitsUnset(app, limits, limitType)
+	return cmdr.LimitsUnset(app, limits, limitType)
 }

--- a/parser/maintenance.go
+++ b/parser/maintenance.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Maintenance displays all relevant commands for `deis maintenance`.
-func Maintenance(argv []string) error {
+func Maintenance(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for maintenance:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "maintenance:info":
-		return maintenanceInfo(argv)
+		return maintenanceInfo(argv, cmdr)
 	case "maintenance:on":
-		return maintenanceEnable(argv)
+		return maintenanceEnable(argv, cmdr)
 	case "maintenance:off":
-		return maintenanceDisable(argv)
+		return maintenanceDisable(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "maintenance" {
 			argv[0] = "maintenance:info"
-			return maintenanceInfo(argv)
+			return maintenanceInfo(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func maintenanceInfo(argv []string) error {
+func maintenanceInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application's maintenance state.
 
@@ -56,10 +56,10 @@ Options:
 		return err
 	}
 
-	return cmd.MaintenanceInfo(safeGetValue(args, "--app"))
+	return cmdr.MaintenanceInfo(safeGetValue(args, "--app"))
 }
 
-func maintenanceEnable(argv []string) error {
+func maintenanceEnable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Enables maintenance mode for an app.
 
@@ -76,10 +76,10 @@ Options:
 		return err
 	}
 
-	return cmd.MaintenanceEnable(safeGetValue(args, "--app"))
+	return cmdr.MaintenanceEnable(safeGetValue(args, "--app"))
 }
 
-func maintenanceDisable(argv []string) error {
+func maintenanceDisable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Disables maintenance mode for an app.
 
@@ -96,5 +96,5 @@ Options:
 		return err
 	}
 
-	return cmd.MaintenanceDisable(safeGetValue(args, "--app"))
+	return cmdr.MaintenanceDisable(safeGetValue(args, "--app"))
 }

--- a/parser/perms.go
+++ b/parser/perms.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Perms routes perms commands to their specific function.
-func Perms(argv []string) error {
+func Perms(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for perms:
 
@@ -16,13 +16,14 @@ perms:delete          delete a permission for a user
 
 Use 'deis help perms:[command]' to learn more.
 `
+
 	switch argv[0] {
 	case "perms:list":
-		return permsList(argv)
+		return permsList(argv, cmdr)
 	case "perms:create":
-		return permCreate(argv)
+		return permCreate(argv, cmdr)
 	case "perms:delete":
-		return permDelete(argv)
+		return permDelete(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -30,7 +31,7 @@ Use 'deis help perms:[command]' to learn more.
 
 		if argv[0] == "perms" {
 			argv[0] = "perms:list"
-			return permsList(argv)
+			return permsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -38,7 +39,7 @@ Use 'deis help perms:[command]' to learn more.
 	}
 }
 
-func permsList(argv []string) error {
+func permsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists all users with permission to use an app, or lists all users with system
 administrator privileges.
@@ -52,8 +53,7 @@ Options:
   --admin
     lists all users with system administrator privileges.
   -l --limit=<num>
-    the maximum number of results to display, defaults to config setting
-`
+    the maximum number of results to display, defaults to config setting`
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
@@ -61,6 +61,7 @@ Options:
 		return err
 	}
 
+	app := safeGetValue(args, "--app")
 	admin := args["--admin"].(bool)
 
 	results, err := responseLimit(safeGetValue(args, "--limit"))
@@ -69,10 +70,10 @@ Options:
 		return err
 	}
 
-	return cmd.PermsList(safeGetValue(args, "--app"), admin, results)
+	return cmdr.PermsList(app, admin, results)
 }
 
-func permCreate(argv []string) error {
+func permCreate(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Gives another user permission to use an app, or gives another user
 system administrator privileges.
@@ -101,10 +102,10 @@ Options:
 	username := args["<username>"].(string)
 	admin := args["--admin"].(bool)
 
-	return cmd.PermCreate(app, username, admin)
+	return cmdr.PermCreate(app, username, admin)
 }
 
-func permDelete(argv []string) error {
+func permDelete(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Revokes another user's permission to use an app, or revokes another user's system
 administrator privileges.
@@ -120,8 +121,7 @@ Options:
     revokes <username> permission to use <app>. <app> is the uniquely identifiable name
     for the application.
   --admin
-    revokes <username> system administrator privileges.
-`
+    revokes <username> system administrator privileges.`
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
 
@@ -133,5 +133,5 @@ Options:
 	username := args["<username>"].(string)
 	admin := args["--admin"].(bool)
 
-	return cmd.PermDelete(app, username, admin)
+	return cmdr.PermDelete(app, username, admin)
 }

--- a/parser/ps.go
+++ b/parser/ps.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Ps routes ps commands to their specific function.
-func Ps(argv []string) error {
+func Ps(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for processes:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "ps:list":
-		return psList(argv)
+		return psList(argv, cmdr)
 	case "ps:restart":
-		return psRestart(argv)
+		return psRestart(argv, cmdr)
 	case "ps:scale":
-		return psScale(argv)
+		return psScale(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "ps" {
 			argv[0] = "ps:list"
-			return psList(argv)
+			return psList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func psList(argv []string) error {
+func psList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists processes servicing an application.
 
@@ -56,10 +56,10 @@ Options:
 	}
 
 	// The 1000 is fake for now until API understands limits
-	return cmd.PsList(safeGetValue(args, "--app"), 1000)
+	return cmdr.PsList(safeGetValue(args, "--app"), 1000)
 }
 
-func psRestart(argv []string) error {
+func psRestart(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Restart an application, a process type or a specific process.
 
@@ -81,10 +81,12 @@ Options:
 		return err
 	}
 
-	return cmd.PsRestart(safeGetValue(args, "--app"), safeGetValue(args, "<type>"))
+	apps := safeGetValue(args, "--app")
+	tp := safeGetValue(args, "<type>")
+	return cmdr.PsRestart(apps, tp)
 }
 
-func psScale(argv []string) error {
+func psScale(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Scales an application's processes by type.
 
@@ -108,5 +110,6 @@ Options:
 		return err
 	}
 
-	return cmd.PsScale(safeGetValue(args, "--app"), args["<type>=<num>"].([]string))
+	apps := safeGetValue(args, "--app")
+	return cmdr.PsScale(apps, args["<type>=<num>"].([]string))
 }

--- a/parser/registry.go
+++ b/parser/registry.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Registry routes registry commands to their specific function
-func Registry(argv []string) error {
+func Registry(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for registry:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "registry:list":
-		return registryList(argv)
+		return registryList(argv, cmdr)
 	case "registry:set":
-		return registrySet(argv)
+		return registrySet(argv, cmdr)
 	case "registry:unset":
-		return registryUnset(argv)
+		return registryUnset(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "registry" {
 			argv[0] = "registry:list"
-			return registryList(argv)
+			return registryList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func registryList(argv []string) error {
+func registryList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists registry information for an application.
 
@@ -51,15 +51,14 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
-	return cmd.RegistryList(safeGetValue(args, "--app"))
+	return cmdr.RegistryList(safeGetValue(args, "--app"))
 }
 
-func registrySet(argv []string) error {
+func registrySet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets registry information for an application. These credentials are the same as those used for
 'docker login' to the private registry.
@@ -87,10 +86,10 @@ Options:
 	app := safeGetValue(args, "--app")
 	info := args["<key>=<value>"].([]string)
 
-	return cmd.RegistrySet(app, info)
+	return cmdr.RegistrySet(app, info)
 }
 
-func registryUnset(argv []string) error {
+func registryUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets registry information for an application.
 
@@ -113,5 +112,5 @@ Options:
 	app := safeGetValue(args, "--app")
 	key := args["<key>"].([]string)
 
-	return cmd.RegistryUnset(app, key)
+	return cmdr.RegistryUnset(app, key)
 }

--- a/parser/releases.go
+++ b/parser/releases.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Releases routes releases commands to their specific function.
-func Releases(argv []string) error {
+func Releases(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for releases:
 
@@ -22,11 +22,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "releases:list":
-		return releasesList(argv)
+		return releasesList(argv, cmdr)
 	case "releases:info":
-		return releasesInfo(argv)
+		return releasesInfo(argv, cmdr)
 	case "releases:rollback":
-		return releasesRollback(argv)
+		return releasesRollback(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -34,7 +34,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "releases" {
 			argv[0] = "releases:list"
-			return releasesList(argv)
+			return releasesList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -42,7 +42,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func releasesList(argv []string) error {
+func releasesList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists release history for an application.
 
@@ -56,21 +56,21 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
 	results, err := responseLimit(safeGetValue(args, "--limit"))
-
 	if err != nil {
 		return err
 	}
 
-	return cmd.ReleasesList(safeGetValue(args, "--app"), results)
+	app := safeGetValue(args, "--app")
+
+	return cmdr.ReleasesList(app, results)
 }
 
-func releasesInfo(argv []string) error {
+func releasesInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about a particular release.
 
@@ -93,10 +93,12 @@ Options:
 		return err
 	}
 
-	return cmd.ReleasesInfo(safeGetValue(args, "--app"), version)
+	app := safeGetValue(args, "--app")
+
+	return cmdr.ReleasesInfo(app, version)
 }
 
-func releasesRollback(argv []string) error {
+func releasesRollback(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Rolls back to a previous application release.
 
@@ -125,7 +127,9 @@ Options:
 		}
 	}
 
-	return cmd.ReleasesRollback(safeGetValue(args, "--app"), version)
+	app := safeGetValue(args, "--app")
+
+	return cmdr.ReleasesRollback(app, version)
 }
 
 func versionFromString(version string) (int, error) {

--- a/parser/routing.go
+++ b/parser/routing.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Routing displays all relevant commands for `deis routing`.
-func Routing(argv []string) error {
+func Routing(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for routing:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "routing:info":
-		return routingInfo(argv)
+		return routingInfo(argv, cmdr)
 	case "routing:enable":
-		return routingEnable(argv)
+		return routingEnable(argv, cmdr)
 	case "routing:disable":
-		return routingDisable(argv)
+		return routingDisable(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "routing" {
 			argv[0] = "routing:info"
-			return routingInfo(argv)
+			return routingInfo(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func routingInfo(argv []string) error {
+func routingInfo(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Prints info about the current application's routability.
 
@@ -51,15 +51,14 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
-	return cmd.RoutingInfo(safeGetValue(args, "--app"))
+	return cmdr.RoutingInfo(safeGetValue(args, "--app"))
 }
 
-func routingEnable(argv []string) error {
+func routingEnable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Enables routability for an app.
 
@@ -71,15 +70,14 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
 
-	return cmd.RoutingEnable(safeGetValue(args, "--app"))
+	return cmdr.RoutingEnable(safeGetValue(args, "--app"))
 }
 
-func routingDisable(argv []string) error {
+func routingDisable(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Disables routability for an app.
 
@@ -96,5 +94,5 @@ Options:
 		return err
 	}
 
-	return cmd.RoutingDisable(safeGetValue(args, "--app"))
+	return cmdr.RoutingDisable(safeGetValue(args, "--app"))
 }

--- a/parser/tags.go
+++ b/parser/tags.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Tags routes tags commands to their specific function
-func Tags(argv []string) error {
+func Tags(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for tags:
 
@@ -19,11 +19,11 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "tags:list":
-		return tagsList(argv)
+		return tagsList(argv, cmdr)
 	case "tags:set":
-		return tagsSet(argv)
+		return tagsSet(argv, cmdr)
 	case "tags:unset":
-		return tagsUnset(argv)
+		return tagsUnset(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -31,7 +31,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "tags" {
 			argv[0] = "tags:list"
-			return tagsList(argv)
+			return tagsList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -39,7 +39,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func tagsList(argv []string) error {
+func tagsList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists tags for an application.
 
@@ -56,10 +56,10 @@ Options:
 		return err
 	}
 
-	return cmd.TagsList(safeGetValue(args, "--app"))
+	return cmdr.TagsList(safeGetValue(args, "--app"))
 }
 
-func tagsSet(argv []string) error {
+func tagsSet(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Sets tags for an application.
 
@@ -79,7 +79,6 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
@@ -87,10 +86,10 @@ Options:
 	app := safeGetValue(args, "--app")
 	tags := args["<key>=<value>"].([]string)
 
-	return cmd.TagsSet(app, tags)
+	return cmdr.TagsSet(app, tags)
 }
 
-func tagsUnset(argv []string) error {
+func tagsUnset(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Unsets tags for an application.
 
@@ -105,7 +104,6 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
@@ -113,5 +111,5 @@ Options:
 	app := safeGetValue(args, "--app")
 	tags := args["<key>"].([]string)
 
-	return cmd.TagsUnset(app, tags)
+	return cmdr.TagsUnset(app, tags)
 }

--- a/parser/users.go
+++ b/parser/users.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Users routes user commands to the specific function.
-func Users(argv []string) error {
+func Users(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Valid commands for users:
 
@@ -17,7 +17,7 @@ Use 'deis help [command]' to learn more.
 
 	switch argv[0] {
 	case "users:list":
-		return usersList(argv)
+		return usersList(argv, cmdr)
 	default:
 		if printHelp(argv, usage) {
 			return nil
@@ -25,7 +25,7 @@ Use 'deis help [command]' to learn more.
 
 		if argv[0] == "users" {
 			argv[0] = "users:list"
-			return usersList(argv)
+			return usersList(argv, cmdr)
 		}
 
 		PrintUsage()
@@ -33,7 +33,7 @@ Use 'deis help [command]' to learn more.
 	}
 }
 
-func usersList(argv []string) error {
+func usersList(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Lists all registered users.
 Requires admin privilages.
@@ -46,7 +46,6 @@ Options:
 `
 
 	args, err := docopt.Parse(usage, argv, true, "", false, true)
-
 	if err != nil {
 		return err
 	}
@@ -57,5 +56,5 @@ Options:
 		return err
 	}
 
-	return cmd.UsersList(results)
+	return cmdr.UsersList(results)
 }

--- a/settings/utils.go
+++ b/settings/utils.go
@@ -3,14 +3,24 @@ package settings
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 )
 
-func locateSettingsFile() string {
-	filename := os.Getenv("DEIS_PROFILE")
+var filepathRegex = regexp.MustCompile(`^.*[/\\].+\.json$`)
 
-	if filename == "" {
-		filename = "client"
+func locateSettingsFile(cf string) string {
+	if cf == "" {
+		if v, ok := os.LookupEnv("DEIS_PROFILE"); ok {
+			cf = v
+		} else {
+			cf = "client"
+		}
 	}
 
-	return filepath.Join(FindHome(), ".deis", filename+".json")
+	// if path appears to be a filepath (contains a separator and ends in .json) don't alter the path
+	if filepathRegex.MatchString(cf) {
+		return cf
+	}
+
+	return filepath.Join(FindHome(), ".deis", cf+".json")
 }


### PR DESCRIPTION
Usage: `deis -c path/to/config.json`

If you want to quickly switch between different clusters, it also works like $DEIS_PROFILE: `deis -c dev`

`$DEIS_PROFILE` behaves identically to the config flag.

Fixes #28 