### PR TITLE
fix(settings): remove duplicated 'v' in user agent

### DIFF
--- a/settings/settings.go
+++ b/settings/settings.go
@@ -16,7 +16,7 @@ import (
 const DefaultResponseLimit = 100
 
 // UserAgent is the user agent used by the CLI
-var UserAgent = "Deis Client v" + version.Version
+var UserAgent = "Deis Client " + version.Version
 
 type settingsFile struct {
 	Username   string `json:"username"`

--- a/settings/settings_test.go
+++ b/settings/settings_test.go
@@ -68,7 +68,7 @@ func TestLoadSave(t *testing.T) {
 			expected: s.Limit,
 		},
 		{
-			key:      "Deis Client v" + version.Version,
+			key:      "Deis Client " + version.Version,
 			expected: s.Client.UserAgent,
 		},
 	}
@@ -123,7 +123,7 @@ func TestLoadSave(t *testing.T) {
 			expected: s.Limit,
 		},
 		{
-			key:      "Deis Client v" + version.Version,
+			key:      "Deis Client " + version.Version,
 			expected: s.Client.UserAgent,
 		},
 	}


### PR DESCRIPTION
the workflow-cli version is defined based on the git tag which already
has a prepended v (v2.4.0) resulting in the user agent seen below

"GET /v2/apps/foo/pods/?limit=100 HTTP/1.1" 200 593 "Deis Client vv2.4.0"

Fixes #186