### PR TITLE
feat(users): show admins when listing users

### DIFF
--- a/cmd/users.go
+++ b/cmd/users.go
@@ -22,9 +22,12 @@ func (d DeisCmd) UsersList(results int) error {
 		return err
 	}
 
-	d.Printf("=== Users%s", limitCount(len(users), count))
+	d.Printf("=== Users (*=admin)%s", limitCount(len(users), count))
 
 	for _, user := range users {
+		if user.IsSuperuser {
+			d.Print("*")
+		}
 		d.Println(user.Username)
 	}
 	return nil

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/workflow-cli/pkg/testutil"
+)
+
+func TestUsersList(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	server.Mux.HandleFunc("/v2/users/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		fmt.Fprintf(w, `{
+			"count": 2,
+			"next": null,
+			"previous": null,
+			"results": [
+				{
+					"id": 2,
+					"last_login": "2014-10-19T22:01:00.601Z",
+					"is_superuser": false,
+					"username": "test",
+					"first_name": "test",
+					"last_name": "testerson",
+					"email": "test@example.com",
+					"is_staff": false,
+					"is_active": true,
+					"date_joined": "2014-10-19T22:01:00.601Z",
+					"groups": [],
+					"user_permissions": []
+				},
+				{
+					"id": 1,
+					"last_login": "2014-10-19T22:01:00.601Z",
+					"is_superuser": true,
+					"username": "jkirk",
+					"first_name": "james",
+					"last_name": "kirk",
+					"email": "jkrik@starfleet.ufp.gov",
+					"is_staff": true,
+					"is_active": true,
+					"date_joined": "2014-10-19T22:01:00.601Z",
+					"groups": [],
+					"user_permissions": []
+				}
+			]
+		}`)
+	})
+
+	err = cmdr.UsersList(-1)
+	assert.NoErr(t, err)
+
+	assert.Equal(t, b.String(), `=== Users (*=admin)
+test
+*jkirk
+`, "output")
+}

--- a/parser/users.go
+++ b/parser/users.go
@@ -35,7 +35,7 @@ Use 'deis help [command]' to learn more.
 
 func usersList(argv []string, cmdr cmd.Commander) error {
 	usage := `
-Lists all registered users.
+Lists all registered users. Workflow administrators will be marked with a *.
 Requires admin privileges.
 
 Usage: deis users:list [options]


### PR DESCRIPTION
Also added tests to cover the behavior

This will probably break e2e, but I'm questioning the need for `users:list` e2e tests. It's tested in the controller, the sdk, and cli, so as long as the api contract stays the same (which we commit to by using semver) it should work.