### PR TITLE
feat(Makefile): build using dockefile and slim image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 Dockerfile
 vendor
+_dist
+.git


### PR DESCRIPTION
Switch to building within the dockerfile as well.
This also excludes unneeded files from the container, so the `COPY` step at the end remains fast.
On my macbook a cached containerized `make build` takes the same amount of time as a `go build` on the host machine.

This also slims up test images, hopefully speeding up CI.

Another bonus: No more, "did you run `make glideup`". Dockers caching system will automatically download new dependencies when they change.

⚠️ the deis binary is now saved to `_dist/deis` so that you don't have to mount the entire working directory into the docker container.