### PR TITLE
feat(version): add deis version --all

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -90,6 +90,7 @@ type Commander interface {
 	PrintErrln(...interface{}) (int, error)
 	PrintErr(...interface{}) (int, error)
 	PrintErrf(string, ...interface{}) (int, error)
+	Version(bool) error
 }
 
 // DeisCmd is an implementation of Commander.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	deis "github.com/deis/controller-sdk-go"
+	"github.com/deis/workflow-cli/settings"
+	"github.com/deis/workflow-cli/version"
+)
+
+// Version prints the various CLI versions.
+func (d DeisCmd) Version(all bool) error {
+	if !all {
+		d.Println(version.Version)
+		return nil
+	}
+
+	d.Printf("Workflow CLI Version:            %s\n", version.Version)
+	d.Printf("Workflow CLI API Version:        %s\n", deis.APIVersion)
+
+	s, err := settings.Load(d.ConfigFile)
+
+	if err != nil {
+		return err
+	}
+
+	// retrive version information from deis controller
+	err = s.Client.Healthcheck()
+
+	if err != nil && err != deis.ErrAPIMismatch {
+		return err
+	}
+
+	d.Printf("Workflow Controller API Version: %s\n", s.Client.ControllerAPIVersion)
+	return nil
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/controller-sdk-go"
+	"github.com/deis/workflow-cli/pkg/testutil"
+	"github.com/deis/workflow-cli/version"
+)
+
+func TestVersion(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	server.Mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("DEIS_API_VERSION", "1234")
+		w.WriteHeader(200)
+	})
+
+	err = cmdr.Version(true)
+	assert.NoErr(t, err)
+
+	assert.Equal(t, b.String(), fmt.Sprintf(`Workflow CLI Version:            %s
+Workflow CLI API Version:        %s
+Workflow Controller API Version: 1234
+`, version.Version, deis.APIVersion), "output")
+
+	b.Reset()
+	err = cmdr.Version(false)
+	assert.NoErr(t, err)
+	assert.Equal(t, b.String(), version.Version+"\n", "output")
+}

--- a/deis.go
+++ b/deis.go
@@ -149,7 +149,7 @@ Use 'git push deis master' to deploy to an application.
 	case "users":
 		err = parser.Users(argv, &cmdr)
 	case "version":
-		err = parser.Version(argv)
+		err = parser.Version(argv, &cmdr)
 	case "whitelist":
 		err = parser.Whitelist(argv, &cmdr)
 	default:

--- a/parser/version.go
+++ b/parser/version.go
@@ -1,26 +1,25 @@
 package parser
 
 import (
-	"fmt"
-
-	"github.com/deis/workflow-cli/version"
+	"github.com/deis/workflow-cli/cmd"
 	docopt "github.com/docopt/docopt-go"
 )
 
 // Version displays the client version
-func Version(argv []string) error {
+func Version(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Displays the client version.
 
-Usage: deis version
+Usage: deis version [options]
 
-Use 'deis help [command]' to learn more.
+Options:
+  -a --all
+    list api and controller versions
 `
-	if _, err := docopt.Parse(usage, argv, true, "", false, true); err != nil {
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+	if err != nil {
 		return err
 	}
 
-	fmt.Println(version.Version)
-
-	return nil
+	return cmdr.Version(args["--all"].(bool))
 }


### PR DESCRIPTION
Fixes #25 

I'm not including `client.ControllerVersion` because it's not what it seems to be. It's the untruncated API version string. This is not the same as the deis platform version or the controller image version, so it would just confuse people.