### PR TITLE
feat(Makefile): add build-stable target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ build-revision:
 	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${REVISION}/deis-${REVISION}-{{.OS}}-{{.Arch}}" .
 
 # This is supposed to be run within a docker container
+build-stable:
+	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
+	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/deis-stable-{{.OS}}-{{.Arch}}" .
+
+# This is supposed to be run within a docker container
 build-tag:
 	$(eval GO_LDFLAGS = -ldflags '-X ${repo_path}/version.Version=${GIT_TAG}')
 	gox -verbose ${GO_LDFLAGS} -os="${BUILD_OS}" -arch="${BUILD_ARCH}" -output="${DIST_DIR}/${GIT_TAG}/deis-${GIT_TAG}-{{.OS}}-{{.Arch}}" .


### PR DESCRIPTION
To upload/overwrite the `deis-stable-*` binaries on each release, in a similar manner as we do for `latest`/master commits.

(Not tied to the keyword `stable` and open to suggestions for better naming)

TODO
 - [x] appropriate update PR in deis/jenkins-jobs: https://github.com/deis/jenkins-jobs/pull/230
 - [x] appropriate PR in deis/workflow-e2e: https://github.com/deis/workflow-e2e/pull/321
 - [x] appropriate update PR to https://github.com/deis/deis.io/blob/gh-pages/deis-cli/install-v2.sh#L13: https://github.com/deis/deis.io/pull/182

cc @Joshua-Anderson 