### PR TITLE
feat(git): clean up git package and write tests

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -48,7 +48,7 @@ func (d *DeisCmd) AppCreate(id, buildpack, remote string, noRemote bool) error {
 	}
 
 	if !noRemote {
-		if err = git.CreateRemote(s.Client.ControllerURL.Host, remote, app.ID); err != nil {
+		if err = git.CreateRemote(git.DefaultCmd, s.Client.ControllerURL.Host, remote, app.ID); err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf("fatal: remote %s already exists.", remote)) {
 				msg := "A git remote with the name %s already exists. To overwrite this remote run:\n"
 				msg += "deis git:remote --force --remote %s --app %s"
@@ -219,7 +219,7 @@ func (d *DeisCmd) AppDestroy(appID, confirm string) error {
 	}
 
 	if appID == "" {
-		appID, err = git.DetectAppName(s.Client.ControllerURL.Host)
+		appID, err = git.DetectAppName(git.DefaultCmd, s.Client.ControllerURL.Host)
 
 		if err != nil {
 			return err

--- a/cmd/apps_test.go
+++ b/cmd/apps_test.go
@@ -66,8 +66,8 @@ func TestRemoteExists(t *testing.T) {
 
 	assert.NoErr(t, os.Chdir(dir))
 
-	assert.NoErr(t, git.Init())
-	assert.NoErr(t, git.CreateRemote("localhost", "deis", "appname"))
+	assert.NoErr(t, git.Init(git.DefaultCmd))
+	assert.NoErr(t, git.CreateRemote(git.DefaultCmd, "localhost", "deis", "appname"))
 
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -13,12 +13,12 @@ const remoteDeletionMsg = "Git remotes for app %s removed.\n"
 func (d *DeisCmd) GitRemote(appID, remote string, force bool) error {
 	s, appID, err := load(d.ConfigFile, appID)
 
-	remoteURL, err := git.RemoteValue(remote)
+	remoteURL, err := git.RemoteURL(git.DefaultCmd, remote)
 
 	if err != nil {
 		//If git remote doesn't exist, create it without issue
 		if err == git.ErrRemoteNotFound {
-			err := git.CreateRemote(s.Client.ControllerURL.Host, remote, appID)
+			err := git.CreateRemote(git.DefaultCmd, s.Client.ControllerURL.Host, remote, appID)
 			if err != nil {
 				return err
 			}
@@ -29,7 +29,7 @@ func (d *DeisCmd) GitRemote(appID, remote string, force bool) error {
 		return err
 	}
 
-	expectedURL := git.RemoteURL(s.Client.ControllerURL.Host, appID)
+	expectedURL := git.RepositoryURL(s.Client.ControllerURL.Host, appID)
 
 	if remoteURL == expectedURL {
 		d.Printf("Remote %s already exists and is correctly configured for app %s.\n", remote, appID)
@@ -38,11 +38,11 @@ func (d *DeisCmd) GitRemote(appID, remote string, force bool) error {
 
 	if force {
 		d.Printf("Deleting git remote %s.\n", remote)
-		err := git.DeleteRemote(remote)
+		err := git.DeleteRemote(git.DefaultCmd, remote)
 		if err != nil {
 			return err
 		}
-		err = git.CreateRemote(s.Client.ControllerURL.Host, remote, appID)
+		err = git.CreateRemote(git.DefaultCmd, s.Client.ControllerURL.Host, remote, appID)
 		if err != nil {
 			return err
 		}
@@ -65,7 +65,7 @@ func (d *DeisCmd) GitRemove(appID string) error {
 		return err
 	}
 
-	err = git.DeleteAppRemotes(s.Client.ControllerURL.Host, appID)
+	err = git.DeleteAppRemotes(git.DefaultCmd, s.Client.ControllerURL.Host, appID)
 
 	if err != nil {
 		return err

--- a/cmd/perms.go
+++ b/cmd/perms.go
@@ -103,7 +103,7 @@ func permsLoad(cf, appID string, admin bool) (*settings.Settings, string, error)
 	}
 
 	if !admin && appID == "" {
-		appID, err = git.DetectAppName(s.Client.ControllerURL.Host)
+		appID, err = git.DetectAppName(git.DefaultCmd, s.Client.ControllerURL.Host)
 
 		if err != nil {
 			return nil, "", err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -46,7 +46,7 @@ func load(cf string, appID string) (*settings.Settings, string, error) {
 	}
 
 	if appID == "" {
-		appID, err = git.DetectAppName(s.Client.ControllerURL.Host)
+		appID, err = git.DetectAppName(git.DefaultCmd, s.Client.ControllerURL.Host)
 
 		if err != nil {
 			return nil, "", err

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -40,8 +40,8 @@ func TestLoad(t *testing.T) {
 	assert.NoErr(t, err)
 	assert.Equal(t, appID, filepath.Base(name), "app")
 
-	assert.NoErr(t, git.Init())
-	assert.NoErr(t, git.CreateRemote(host, "deis", "testing"))
+	assert.NoErr(t, git.Init(git.DefaultCmd))
+	assert.NoErr(t, git.CreateRemote(git.DefaultCmd, host, "deis", "testing"))
 
 	_, appID, err = load(filename, "")
 	assert.NoErr(t, err)

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -1,23 +1,271 @@
 package git
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/arschles/assert"
 )
+
+func TestRepositoryURL(t *testing.T) {
+	t.Parallel()
+
+	actual := RepositoryURL("deis.example.com", "app")
+	assert.Equal(t, actual, "ssh://git@deis-builder.example.com:2222/app.git", "url")
+	actual = RepositoryURL("deis.10.245.1.3.xip.io:31350", "velcro-underdog")
+	assert.Equal(t, actual, "ssh://git@deis-builder.10.245.1.3.xip.io:2222/velcro-underdog.git", "url")
+}
+
+func TestGetRemotes(t *testing.T) {
+	t.Parallel()
+
+	expected := []remote{
+		{"test", "ssh://test.com/test.git"},
+		{"example", "ssh://example.com:2222/example.git"},
+	}
+
+	actual, err := getRemotes(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+example	ssh://example.com:2222/example.git (fetch)
+example	ssh://example.com:2222/example.git (push)
+`, nil
+	})
+
+	assert.NoErr(t, err)
+	assert.Equal(t, actual, expected, "remotes")
+
+	_, err = getRemotes(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `fakeoutput(push)
+`, nil
+	})
+
+	assert.Err(t, err, ErrInvalidRepositoryList)
+
+	testErr := errors.New("test error")
+
+	_, err = getRemotes(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return "", testErr
+	})
+
+	assert.Err(t, err, testErr)
+}
 
 func TestRemoteURL(t *testing.T) {
 	t.Parallel()
 
-	actual := RemoteURL("deis.example.com", "app")
-	expected := "ssh://git@deis-builder.example.com:2222/app.git"
+	url, err := RemoteURL(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+example	ssh://example.com:2222/example.git (fetch)
+example	ssh://example.com:2222/example.git (push)
+`, nil
+	}, "test")
 
-	if actual != expected {
-		t.Errorf("Expected %s, Got %s", expected, actual)
-	}
+	assert.NoErr(t, err)
+	assert.Equal(t, url, "ssh://test.com/test.git", "remote url")
 
-	actual = RemoteURL("deis.10.245.1.3.xip.io:31350", "velcro-underdog")
-	expected = "ssh://git@deis-builder.10.245.1.3.xip.io:2222/velcro-underdog.git"
+	_, err = RemoteURL(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+example	ssh://example.com:2222/example.git (fetch)
+example	ssh://example.com:2222/example.git (push)
+`, nil
+	}, "foo")
 
-	if actual != expected {
-		t.Errorf("Expected %s, Got %s", expected, actual)
-	}
+	assert.Err(t, err, ErrRemoteNotFound)
+
+	testErr := errors.New("test error")
+
+	_, err = RemoteURL(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return "", testErr
+	}, "test")
+
+	assert.Err(t, err, testErr)
+}
+
+func TestFindRemoteURL(t *testing.T) {
+	t.Parallel()
+
+	url, err := findRemote(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+deis	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+	}, "deis.example.com")
+
+	assert.NoErr(t, err)
+	assert.Equal(t, url, "ssh://git@deis-builder.example.com:2222/test.git", "remote url")
+
+	_, err = findRemote(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+example	ssh://example.com:2222/example.git (fetch)
+example	ssh://example.com:2222/example.git (push)
+`, nil
+	}, "deis.test.com")
+
+	assert.Err(t, err, ErrRemoteNotFound)
+
+	testErr := errors.New("test error")
+
+	_, err = findRemote(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return "", testErr
+	}, "deis.test.com")
+
+	assert.Err(t, err, testErr)
+}
+
+func TestDetectAppName(t *testing.T) {
+	t.Parallel()
+
+	app, err := DetectAppName(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `deis	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+	}, "deis.example.com")
+
+	assert.NoErr(t, err)
+	assert.Equal(t, app, "test", "app")
+
+	app, err = DetectAppName(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return "", errors.New("test error")
+	}, "deis.test.com")
+	wd, err := os.Getwd()
+	assert.NoErr(t, err)
+	assert.Equal(t, app, filepath.Base(wd), "app")
+}
+
+func TestRemoteNamesFromAppID(t *testing.T) {
+	t.Parallel()
+
+	apps, err := remoteNamesFromAppID(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+deis	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+two	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+two	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+	}, "deis.example.com", "test")
+
+	assert.NoErr(t, err)
+	assert.Equal(t, apps, []string{"deis", "two"}, "remote url")
+
+	_, err = remoteNamesFromAppID(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return `test	ssh://test.com/test.git (fetch)
+test	ssh://test.com/test.git (push)
+deis	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+two	ssh://git@deis-builder.example.com:2222/test.git (fetch)
+two	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+	}, "deis.test.com", "other")
+
+	assert.Err(t, err, ErrRemoteNotFound)
+
+	testErr := errors.New("test error")
+
+	_, err = remoteNamesFromAppID(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "-v"}, "args")
+		return "", testErr
+	}, "deis.test.com", "test")
+
+	assert.Err(t, err, testErr)
+}
+
+func TestDeleteRemote(t *testing.T) {
+	t.Parallel()
+
+	err := DeleteRemote(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "remove", "test"}, "args")
+		return "", nil
+	}, "test")
+	assert.NoErr(t, err)
+}
+
+func TestDeleteAppRemotes(t *testing.T) {
+	t.Parallel()
+
+	err := DeleteAppRemotes(func(cmd []string) (string, error) {
+		if reflect.DeepEqual(cmd, []string{"remote", "-v"}) {
+			return `deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+		} else if reflect.DeepEqual(cmd, []string{"remote", "remove", "deis"}) {
+			return "", nil
+		} else {
+			t.Errorf("unexpected command %v", cmd)
+			return "", nil
+		}
+	}, "deis.example.com", "test")
+
+	assert.NoErr(t, err)
+
+	testErr := errors.New("test error")
+
+	err = DeleteAppRemotes(func(cmd []string) (string, error) {
+		return "", testErr
+	}, "deis.example.com", "test")
+
+	assert.Err(t, testErr, err)
+
+	err = DeleteAppRemotes(func(cmd []string) (string, error) {
+		if reflect.DeepEqual(cmd, []string{"remote", "-v"}) {
+			return `deis	ssh://git@deis-builder.example.com:2222/test.git (push)
+`, nil
+		} else if reflect.DeepEqual(cmd, []string{"remote", "remove", "deis"}) {
+			return "", testErr
+		} else {
+			t.Errorf("unexpected command %v", cmd)
+			return "", nil
+		}
+	}, "deis.example.com", "test")
+
+	assert.Err(t, testErr, err)
+}
+
+func TestInit(t *testing.T) {
+	t.Parallel()
+
+	err := Init(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"init"}, "args")
+		return "", nil
+	})
+	assert.NoErr(t, err)
+}
+
+func TestCreateRemote(t *testing.T) {
+	t.Parallel()
+
+	err := CreateRemote(func(cmd []string) (string, error) {
+		assert.Equal(t, cmd, []string{"remote", "add", "deis", "ssh://git@deis-builder.example.com:2222/testing.git"}, "args")
+		return "", nil
+	}, "deis.example.com", "deis", "testing")
+	assert.NoErr(t, err)
+}
+
+func TestGitError(t *testing.T) {
+	t.Parallel()
+
+	exitErr := exec.ExitError{Stderr: []byte("fake error")}
+	assert.Equal(t, gitError(&exitErr, []string{"fake"}).Error(), `Error when running 'git fake'
+fake error`, "error")
 }


### PR DESCRIPTION
Removes duplicate `git remote -v` logic, and removes `git get-url` fixing #196.