### PR TITLE
fix(config): support CRLF config files

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -252,6 +252,8 @@ func (d DeisCmd) ConfigPush(appID, fileName string) error {
 	config := []string{}
 
 	for _, configVar := range file {
+		// If file has CRLF encoding, the default on windows, strip the CR
+		configVar = strings.Trim(configVar, "\r")
 		if len(configVar) > 0 {
 			config = append(config, configVar)
 		}


### PR DESCRIPTION
Sorry I didn't add any tests for this. I'm not sure of any ways to easily test `config:pull` and `config:push` because I need to mock `os.ModeCharDevice` and I don't have the time to investigate it right now. 😢 

How to manually test:

Create a .env file with CRLF line endings and...

Before fix:
```
deis config:push
...
deis run 'printf %q $TEST'
Running 'printf %q $TEST'...
$'123456\r'
```

After fix:
```
deis config:push
...
deis run 'printf %q $TEST'
Running 'printf %q $TEST'...
123456
```