### PR TITLE
chore(Dockerfile): update go-dev and go toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/go-dev:0.17.0
+FROM quay.io/deis/go-dev:0.19.0
 # This Dockerfile is used to bundle the source and all dependencies into an image for testing.
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-jessie main" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY glide.lock /go/src/github.com/deis/workflow-cli/
 
 WORKDIR /go/src/github.com/deis/workflow-cli
 
-RUN glide install --strip-vcs --strip-vendor
+RUN glide install --strip-vendor
 
 COPY ./_scripts /usr/local/bin
 


### PR DESCRIPTION
See https://github.com/golang/go/issues?q=milestone%3AGo1.7.1
and https://github.com/deis/docker-go-dev/releases/tag/0.17.1

Closes #240.