### PR TITLE
fix(deis.go): do not add top level command to cmdArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,25 +79,19 @@ $ mv deis /usr/local/bin
 
 To compile the client from scratch, ensure you have Docker installed and run
 
-	$ make bootstrap
-	$ make build
-
-`make bootstrap` will fetch all required dependencies, while `make build` will compile and install
-the client in the current directory.
-
-	$ ./deis --version
+    $ make
 
 ### From Scratch on Windows
 
 To compile the client from scratch, open PowerShell and execute the following commands in the source directory.
 
-	$ .\make bootstrap
-	$ .\make build
+    $ .\make bootstrap
+    $ .\make build
 
 `.\make bootstrap` will fetch all required dependencies, while `.\make build` will compile and install
 the client in the current directory.
 
-	$ .\deis --version
+    $ .\deis --version
 
 ## Usage
 

--- a/deis.go
+++ b/deis.go
@@ -14,6 +14,8 @@ import (
 	docopt "github.com/docopt/docopt-go"
 )
 
+const extensionPrefix = "deis-"
+
 // main exits with the return value of Command(os.Args[1:]), deferring all logic to
 // a func we can test.
 func main() {
@@ -154,23 +156,14 @@ Use 'git push deis master' to deploy to an application.
 		err = parser.Whitelist(argv, &cmdr)
 	default:
 		env := os.Environ()
-		extCmd := "deis-" + command
 
-		binary, err := exec.LookPath(extCmd)
+		binary, err := exec.LookPath(extensionPrefix + command)
 		if err != nil {
 			parser.PrintUsage(&cmdr)
 			return 1
 		}
 
-		cmdArgv := []string{extCmd}
-
-		cmdSplit := strings.Split(argv[0], command+":")
-
-		if len(cmdSplit) > 1 {
-			argv[0] = cmdSplit[1]
-		}
-
-		cmdArgv = append(cmdArgv, argv...)
+		cmdArgv := prepareCmdArgs(command, argv)
 
 		err = syscall.Exec(binary, cmdArgv, env)
 		if err != nil {
@@ -247,6 +240,18 @@ func parseArgs(argv []string) (string, []string) {
 	}
 
 	return "", argv
+}
+
+// split original command and pass its first element in arguments
+func prepareCmdArgs(command string, argv []string) []string {
+	cmdArgv := []string{extensionPrefix + command}
+	cmdSplit := strings.Split(argv[0], command+":")
+
+	if len(cmdSplit) > 1 {
+		cmdArgv = append(cmdArgv, cmdSplit[1])
+	}
+
+	return append(cmdArgv, argv[1:]...)
 }
 
 func replaceShortcut(command string) string {

--- a/deis_test.go
+++ b/deis_test.go
@@ -63,6 +63,32 @@ func TestCommandSplitting(t *testing.T) {
 	}
 }
 
+func TestTopLevelCommandArgsPreparing(t *testing.T) {
+	t.Parallel()
+
+	command := "ssh"
+	argv := []string{"ssh"}
+	expected := []string{"deis-ssh"}
+	actual := prepareCmdArgs(command, argv)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, Got %v", expected, actual)
+	}
+}
+
+func TestCommandWithParameterArgsPreparing(t *testing.T) {
+	t.Parallel()
+
+	command := "ssh --help"
+	argv := []string{"ssh --help"}
+	expected := []string{"deis-ssh --help"}
+	actual := prepareCmdArgs(command, argv)
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("Expected %v, Got %v", expected, actual)
+	}
+}
+
 func TestReplaceShortcutRepalce(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**Ported from V1: https://github.com/deis/deis/pull/5099.**

---

## Background

We have a private PaaS with multiple Deis clusters (staging + two productions at the moment). We have also a tool that allows us to manage all clusters from a single web panel. It also connects other APIs such as servers provider and DNS provider. As the result we can perform actions that touches many parts of the system (for example create DNS records for all Deis workers and make CNAME to use with `DEISCTL_TUNNEL` or create a database and assign `DATABASE_URL` for a given application). We have also created plugins to extend Deis CLI. For example there is a support for database (+backups) management and easy SSH access for our developers.

## Problem

We have `deis backups:[create|show|restore|list]` commands and we want to show usage help if user tries `deis backups`. There is a problem in such case because Deis CLI invokes `deis-backups backups`. Without additional support on the plugin side, it will throw an invalid command error.

## Solution

We can solve it on the plugin side to handle unexpected arguments, but it feels not okay. Instead, Deis CLI should skip top level command (`backups` in this case) in `cmdArgv`. It already does that when used as `deis backups:list` or even `deis backups:`.

## Code snippets

The output contains output using the following patch:

```diff
diff --git a/deis.go b/deis.go
index 6096618..85e574e 100644
--- a/deis.go
+++ b/deis.go
@@ -165,6 +165,12 @@ Use 'git push deis master' to deploy to an application.

                cmdArgv := prepareCmdArgs(command, argv)

+               fmt.Fprintf(wErr, "command: %s\n", command)
+               fmt.Fprintf(wErr, "argv: %s\n", argv)
+               fmt.Fprintf(wErr, "binary: %v\n", binary)
+               fmt.Fprintf(wErr, "cmdArgv: %v\n", cmdArgv)
+               return 1
+
                err = syscall.Exec(binary, cmdArgv, env)
                if err != nil {
                        parser.PrintUsage(&cmdr)
```

### After

```bash
workflow-cli λ ./_dist/deis backups
command: backups
argv: [backups]
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups]

workflow-cli λ ./_dist/deis backups:list
command: backups
argv: [backups:list]
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups list]

workflow-cli λ ./_dist/deis backups --info
command: backups
argv: [backups --info]
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups --info]

workflow-cli λ ./_dist/deis backups:create --info
command: backups
argv: [backups:create --info]
binary: /Users/smefju/.rbenv/shims/deis-backups
cmdArgv: [deis-backups create --info]
```

---

@bacongobbler I have extracted code to the `prepareCmdArgs` function to make it testable. I can make it the same in V1 if approach is okay. There is one spec missing:

```go
func TestNastedCommandArgsPreparing(t *testing.T) {
	t.Parallel()

	command := "ssh"
	argv := []string{"ssh:info"}
	expected := []string{"deis-ssh info"}
	actual := prepareCmdArgs(command, argv)

	// t.Errorf("Expected %v, Got %v", reflect.TypeOf(expected), reflect.TypeOf(actual))
	if !reflect.DeepEqual(expected, actual) {
		t.Errorf("Expected %v, Got %v", expected, actual)
	}
}
```

I have got the following error:

```
--- FAIL: TestNastedCommandArgsPreparing (0.00s)
    deis_test.go:88: Expected [deis-ssh info], Got [deis-ssh info]
```

Both objects are `[]string` type. Not sure where the issue is.