### PR TITLE
feat(keys): add an optional name support for keys:add

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -51,7 +51,7 @@ type Commander interface {
 	HealthchecksUnset(string, string, []string) error
 	KeysList(int) error
 	KeyRemove(string) error
-	KeyAdd(string) error
+	KeyAdd(string, string) error
 	LimitsList(string) error
 	LimitsSet(string, []string, string) error
 	LimitsUnset(string, []string, string) error

--- a/cmd/keys.go
+++ b/cmd/keys.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -63,7 +64,7 @@ func (d *DeisCmd) KeyRemove(keyID string) error {
 }
 
 // KeyAdd adds keys.
-func (d *DeisCmd) KeyAdd(keyLocation string) error {
+func (d *DeisCmd) KeyAdd(name string, keyLocation string) error {
 	s, err := settings.Load(d.ConfigFile)
 
 	if err != nil {
@@ -71,6 +72,16 @@ func (d *DeisCmd) KeyAdd(keyLocation string) error {
 	}
 
 	var key api.KeyCreateRequest
+
+	// check if name is the key
+	if name != "" && keyLocation == "" {
+		// detect of name is a file
+		_, err := os.Stat(name)
+		if err == nil {
+			keyLocation = name
+			name = ""
+		}
+	}
 
 	if keyLocation == "" {
 		ks, err := listKeys(d.WOut)
@@ -86,6 +97,11 @@ func (d *DeisCmd) KeyAdd(keyLocation string) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	// if name is provided by user then overwrite that in the key object
+	if name != "" {
+		key.ID = name
 	}
 
 	d.Printf("Uploading %s to deis...", filepath.Base(key.Name))

--- a/parser/keys.go
+++ b/parser/keys.go
@@ -69,9 +69,13 @@ func keyAdd(argv []string, cmdr cmd.Commander) error {
 	usage := `
 Adds SSH keys for the logged in user.
 
-Usage: deis keys:add [<key>]
+Usage: deis keys:add [<name>] [<key>]
+
+<name> and <key> can be used in either order and are both optional
 
 Arguments:
+  <name>
+    name of the SSH key
   <key>
     a local file path to an SSH public key used to push application code.
 `
@@ -81,7 +85,7 @@ Arguments:
 		return err
 	}
 
-	return cmdr.KeyAdd(safeGetValue(args, "<key>"))
+	return cmdr.KeyAdd(safeGetValue(args, "<name>"), safeGetValue(args, "<key>"))
 }
 
 func keyRemove(argv []string, cmdr cmd.Commander) error {

--- a/parser/keys_test.go
+++ b/parser/keys_test.go
@@ -20,7 +20,7 @@ func (d FakeDeisCmd) KeyRemove(string) error {
 	return errors.New("keys:remove")
 }
 
-func (d FakeDeisCmd) KeyAdd(string) error {
+func (d FakeDeisCmd) KeyAdd(string, string) error {
 	return errors.New("keys:add")
 }
 
@@ -46,7 +46,7 @@ func TestKeys(t *testing.T) {
 			expected: "",
 		},
 		{
-			args:     []string{"keys:add", "key"},
+			args:     []string{"keys:add", "name", "key"},
 			expected: "",
 		},
 		{


### PR DESCRIPTION
This arg can be used interchangably with the key arg to keep backwards compatibility

That allows a user to do `deis keys:add ~/.ssh/secret.pub` and the name is detected or `keys:add magic ~/.ssh/magic.pub` or `deis keys:add travis` and then get the choice list to pick from

Closes #256