### PR TITLE
feat(parser): add --login=true to auth:register

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -72,8 +72,7 @@ func (d *DeisCmd) Register(controller string, username string, password string, 
 
 	d.Printf("Registered %s\n", username)
 
-	s := settings.Settings{Client: c}
-	return d.doLogin(s, username, password)
+	return nil
 }
 
 func (d *DeisCmd) doLogin(s settings.Settings, username, password string) error {

--- a/cmd/auth_test.go
+++ b/cmd/auth_test.go
@@ -53,7 +53,7 @@ func TestRegister(t *testing.T) {
 
 	err = cmdr.Register(server.Server.URL, username, password, email, true)
 	assert.NoErr(t, err)
-	expected := fmt.Sprintf("Registered %s\nLogged in as %s\nConfiguration file written to %s\n", username, username, cf)
+	expected := fmt.Sprintf("Registered %s\n", username)
 
 	assert.Equal(t, b.String(), expected, "output")
 }

--- a/parser/auth.go
+++ b/parser/auth.go
@@ -64,6 +64,8 @@ Options:
     provide a password for the new account.
   --email=<email>
     provide an email address.
+  --login=true
+    logs into the new account after registering.
   --ssl-verify=true
     enables/disables SSL certificate verification for API requests
 `
@@ -84,7 +86,19 @@ Options:
 		sslVerify = false
 	}
 
-	return cmdr.Register(controller, username, password, email, sslVerify)
+	if err := cmdr.Register(controller, username, password, email, sslVerify); err != nil {
+		return err
+	}
+
+	// NOTE(bacongobbler): two use cases to check here:
+	//
+	// 1) Legacy; calling `deis auth:register` without --login
+	// 2) calling `deis auth:register --login true`
+	if args["--login"] == nil || args["--login"].(string) == "true" {
+		return cmdr.Login(controller, username, password, sslVerify)
+	}
+
+	return nil
 }
 
 func authLogin(argv []string, cmdr cmd.Commander) error {

--- a/parser/auth_test.go
+++ b/parser/auth_test.go
@@ -62,6 +62,14 @@ func TestAuth(t *testing.T) {
 			expected: "",
 		},
 		{
+			args:     []string{"auth:register", server.Server.URL, "--ssl-verify=true"},
+			expected: "",
+		},
+		{
+			args:     []string{"auth:register", server.Server.URL, "--login=false"},
+			expected: "",
+		},
+		{
 			args:     []string{"auth:login", server.Server.URL},
 			expected: "",
 		},


### PR DESCRIPTION
This flag allows users to enable/disable automatic login after registering a user.

closes #266