### PR TITLE
feat(cmd): allow config:set FOO=""

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -265,7 +265,7 @@ func (d *DeisCmd) ConfigPush(appID, fileName string) error {
 func parseConfig(configVars []string) (map[string]interface{}, error) {
 	configMap := make(map[string]interface{})
 
-	regex := regexp.MustCompile(`^([A-z_]+[A-z0-9_]*)=([\s\S]+)$`)
+	regex := regexp.MustCompile(`^([A-z_]+[A-z0-9_]*)=([\s\S]*)$`)
 	for _, config := range configVars {
 		// Skip config that starts with an comment
 		if config[0] == '#' {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -20,6 +20,10 @@ func TestParseConfig(t *testing.T) {
 	actual, err := parseConfig([]string{"FOO=bar"})
 	assert.NoErr(t, err)
 	assert.Equal(t, actual, map[string]interface{}{"FOO": "bar"}, "map")
+
+	actual, err = parseConfig([]string{"FOO="})
+	assert.NoErr(t, err)
+	assert.Equal(t, actual, map[string]interface{}{"FOO": ""}, "map")
 }
 
 func TestFormatConfig(t *testing.T) {


### PR DESCRIPTION
Empty string values for an envionment variable is a valid environment variable. This is used when
an application is reading for an environment variable present in the application's environment, but
does not necessarily care about the value.

fixes deis/deis#4802