### PR TITLE
feat(label-cmd): add Label cmd

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -135,6 +135,12 @@ func (d *DeisCmd) AppInfo(appID string) error {
 	}
 
 	d.Println()
+	// print the app labels
+	if err = d.LabelsList(app.ID); err != nil {
+		return err
+	}
+
+	d.Println()
 
 	return nil
 }

--- a/cmd/apps_test.go
+++ b/cmd/apps_test.go
@@ -165,6 +165,20 @@ func TestAppsInfo(t *testing.T) {
 }`)
 	})
 
+	server.Mux.HandleFunc("/v2/apps/lorem-ipsum/settings/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		fmt.Fprintf(w, `{
+			"owner": "elrond",
+			"app": "lorem-ipsum",
+			"created": "2014-01-01T00:00:00UTC",
+			"updated": "2014-01-01T00:00:00UTC",
+			"uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75",
+			"label": {
+				"team": "frontend"
+			}
+		}`)
+	})
+
 	s, err := settings.Load(cmdr.ConfigFile)
 	if err != nil {
 		t.Fatal(err)
@@ -195,6 +209,9 @@ lorem-ipsum-cmd-1911796442-48b58 up (v2)
 
 === lorem-ipsum Domains
 lorem-ipsum
+
+=== lorem-ipsum Label
+team:            frontend
 
 `, "output")
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -52,6 +52,9 @@ type Commander interface {
 	KeysList(int) error
 	KeyRemove(string) error
 	KeyAdd(string, string) error
+	LabelsList(string) error
+	LabelsSet(string, []string) error
+	LabelsUnset(string, []string) error
 	LimitsList(string) error
 	LimitsSet(string, []string, string) error
 	LimitsUnset(string, []string, string) error

--- a/cmd/labels.go
+++ b/cmd/labels.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/deis/controller-sdk-go/api"
+	"github.com/deis/controller-sdk-go/appsettings"
+	"strings"
+)
+
+// LabelsList list app's labels
+func (d *DeisCmd) LabelsList(appID string) error {
+	s, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	appSettings, err := appsettings.List(s.Client, appID)
+	if d.checkAPICompatibility(s.Client, err) != nil {
+		return err
+	}
+
+	d.Printf("=== %s Label\n", appID)
+
+	if appSettings.Label == nil || len(appSettings.Label) == 0 {
+		d.Println("No labels found.")
+	} else {
+		d.Println(appSettings.Label)
+	}
+
+	return nil
+}
+
+// LabelsSet sets labels for app
+func (d *DeisCmd) LabelsSet(appID string, labels []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	labelsMap, err := parseLabels(labels)
+	if err != nil {
+		return err
+	}
+
+	d.Printf("Applying labels on %s... ", appID)
+
+	quit := progress(d.WOut)
+
+	_, err = appsettings.Set(s.Client, appID, api.AppSettings{Label: labelsMap})
+
+	quit <- true
+	<-quit
+
+	if err != nil {
+		return err
+	}
+
+	d.Println("done")
+	return nil
+}
+
+// LabelsUnset removes labels for the app.
+func (d *DeisCmd) LabelsUnset(appID string, labels []string) error {
+	s, appID, err := load(d.ConfigFile, appID)
+
+	if err != nil {
+		return err
+	}
+
+	labelsMap := make(map[string]interface{})
+
+	for _, label := range labels {
+		labelsMap[label] = nil
+	}
+
+	d.Printf("Removing labels on %s... ", appID)
+
+	quit := progress(d.WOut)
+
+	_, err = appsettings.Set(s.Client, appID, api.AppSettings{Label: labelsMap})
+
+	quit <- true
+	<-quit
+
+	if err != nil {
+		return err
+	}
+
+	d.Println("done")
+	return nil
+}
+
+func parseLabels(labels []string) (map[string]interface{}, error) {
+	labelsMap := make(map[string]interface{})
+
+	for _, label := range labels {
+		key, value, err := parseLabel(label)
+
+		if err != nil {
+			return nil, err
+		}
+
+		labelsMap[key] = value
+	}
+
+	return labelsMap, nil
+}
+
+func parseLabel(label string) (string, string, error) {
+	parts := strings.Split(label, "=")
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf(`%s is invalid, Must be in format key=value
+Examples: git_repo=https://github.com/deis/workflow team=frontend`, label)
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/cmd/labels_test.go
+++ b/cmd/labels_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/controller-sdk-go/api"
+	"github.com/deis/workflow-cli/pkg/testutil"
+	"strings"
+)
+
+func TestLabelsList(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	server.Mux.HandleFunc("/v2/apps/rivendell/settings/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		fmt.Fprintf(w, `{
+			"owner": "jim",
+			"app": "rivendell",
+		    "label": {"git_repo": "https://github.com/deis/controller-sdk-go", "team" : "deis"},
+			"created": "2014-01-01T00:00:00UTC",
+			"updated": "2014-01-01T00:00:00UTC",
+			"uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+		}`)
+	})
+
+	err = cmdr.LabelsList("rivendell")
+	assert.NoErr(t, err)
+	assert.Equal(t, strings.TrimSpace(b.String()), `=== rivendell Label
+git_repo:        https://github.com/deis/controller-sdk-go
+team:            deis`, "output")
+
+	server.Mux.HandleFunc("/v2/apps/mordor/settings/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		fmt.Fprintf(w, `{
+			"owner": "priw",
+			"app": "mordor",
+			"created": "2014-01-01T00:00:00UTC",
+			"updated": "2014-01-01T00:00:00UTC",
+			"uuid": "de1bf5b5-4a72-4f94-a10c-d2a3741cdf75"
+		}`)
+	})
+	b.Reset()
+
+	err = cmdr.LabelsList("mordor")
+	assert.NoErr(t, err)
+	assert.Equal(t, b.String(), "=== mordor Label\nNo labels found.\n", "output")
+}
+
+func TestListsSet(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	server.Mux.HandleFunc("/v2/apps/lothlorien/settings/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		data := map[string]interface{}{
+			"git_repo": "https://github.com/deis/controller-sdk-go",
+			"team":     "deis",
+		}
+		testutil.AssertBody(t, api.AppSettings{Label: data}, r)
+		fmt.Fprintf(w, "{}")
+	})
+
+	err = cmdr.LabelsSet("lothlorien", []string{
+		"team=deis",
+		"git_repo=https://github.com/deis/controller-sdk-go",
+	})
+	assert.NoErr(t, err)
+	assert.Equal(t, testutil.StripProgress(b.String()), "Applying labels on lothlorien... done\n", "output")
+}
+
+func TestListsUnset(t *testing.T) {
+	t.Parallel()
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
+
+	server.Mux.HandleFunc("/v2/apps/bree/settings/", func(w http.ResponseWriter, r *http.Request) {
+		testutil.SetHeaders(w)
+		testutil.AssertBody(t, api.AppSettings{Label: map[string]interface{}{
+			"team":     nil,
+			"git_repo": nil,
+		}}, r)
+		fmt.Fprintf(w, "{}")
+	})
+
+	err = cmdr.LabelsUnset("bree", []string{
+		"team",
+		"git_repo",
+	})
+	assert.NoErr(t, err)
+	assert.Equal(t, testutil.StripProgress(b.String()), "Removing labels on bree... done\n", "output")
+}

--- a/deis.go
+++ b/deis.go
@@ -56,6 +56,7 @@ Subcommands, use 'deis help [subcommand]' to learn more::
   git           manage git for applications
   healthchecks  manage healthchecks for applications
   keys          manage ssh keys used for 'git push' deployments
+  labels        manage labels of application
   limits        manage resource limits for your application
   perms         manage permissions for applications
   ps            manage processes inside an app container
@@ -128,6 +129,8 @@ Use 'git push deis master' to deploy to an application.
 		return 0
 	case "keys":
 		err = parser.Keys(argv, &cmdr)
+	case "labels":
+		err = parser.Labels(argv, &cmdr)
 	case "limits":
 		err = parser.Limits(argv, &cmdr)
 	case "perms":

--- a/glide.lock
+++ b/glide.lock
@@ -4,7 +4,7 @@ imports:
 - name: github.com/arschles/assert
   version: bb58b908265b5931732079df03f2818bf2167ba0
 - name: github.com/deis/controller-sdk-go
-  version: bb310847bd314e0f170e807db61acdc33246e0c0
+  version: 685c7f75bc1c4b57899a7cde55d945aa16129513
   subpackages:
   - api
   - apps

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,4 +16,4 @@ import:
 - package: github.com/olekukonko/tablewriter
 - package: github.com/arschles/assert
 - package: github.com/deis/controller-sdk-go
-  version: bb310847bd314e0f170e807db61acdc33246e0c0
+  version: 685c7f75bc1c4b57899a7cde55d945aa16129513

--- a/parser/labels.go
+++ b/parser/labels.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"github.com/deis/workflow-cli/cmd"
+	docopt "github.com/docopt/docopt-go"
+)
+
+// Labels displays all relevant commands for `deis label`.
+func Labels(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Valid commands for labels:
+
+labels:list   list application's labels
+labels:set    add new application's label
+labels:unset  remove application's label
+
+Use 'deis help [command]' to learn more.
+`
+
+	switch argv[0] {
+	case "labels:list":
+		return labelsList(argv, cmdr)
+	case "labels:set":
+		return labelsSet(argv, cmdr)
+	case "labels:unset":
+		return labelsUnset(argv, cmdr)
+	default:
+		if printHelp(argv, usage) {
+			return nil
+		}
+
+		if argv[0] == "labels" {
+			argv[0] = "labels:list"
+			return labelsList(argv, cmdr)
+		}
+
+		PrintUsage(cmdr)
+		return nil
+	}
+}
+
+func labelsList(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Prints a list of labels of the application.
+
+Usage: deis labels:list [options]
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+
+	if err != nil {
+		return err
+	}
+
+	return cmdr.LabelsList(safeGetValue(args, "--app"))
+}
+
+func labelsSet(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Sets labels for an application.
+
+A label is a key/value pair used to label an application. This label is a general information for deis user.
+Mostly used for administraton/maintenance information, note for application. This information isn't send to scheduler.
+
+Usage: deis labels:set [options] <key>=<value>...
+
+Arguments:
+  <key> the label key, for example: "git_repo" or "team"
+  <value> the label value, for example: "https://github.com/deis/workflow" or "frontend"
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+	if err != nil {
+		return err
+	}
+
+	app := safeGetValue(args, "--app")
+	tags := args["<key>=<value>"].([]string)
+
+	return cmdr.LabelsSet(app, tags)
+}
+
+func labelsUnset(argv []string, cmdr cmd.Commander) error {
+	usage := `
+Unsets labels for an application.
+
+Usage: deis labels:unset [options] <key>...
+
+Arguments:
+  <key> the label key to unset, for example: "git_repo" or "team"
+
+Options:
+  -a --app=<app>
+    the uniquely identifiable name for the application.
+`
+
+	args, err := docopt.Parse(usage, argv, true, "", false, true)
+	if err != nil {
+		return err
+	}
+
+	app := safeGetValue(args, "--app")
+	tags := args["<key>"].([]string)
+
+	return cmdr.LabelsUnset(app, tags)
+}

--- a/parser/labels_test.go
+++ b/parser/labels_test.go
@@ -1,0 +1,74 @@
+package parser
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/arschles/assert"
+	"github.com/deis/workflow-cli/pkg/testutil"
+)
+
+// Create fake implementations of each method that return the argument
+// we expect to have called the function (as an error to satisfy the interface).
+
+func (d FakeDeisCmd) LabelsList(string) error {
+	return errors.New("labels:list")
+}
+
+func (d FakeDeisCmd) LabelsSet(string, []string) error {
+	return errors.New("labels:set")
+}
+
+func (d FakeDeisCmd) LabelsUnset(string, []string) error {
+	return errors.New("labels:unset")
+}
+
+func TestLabels(t *testing.T) {
+	t.Parallel()
+
+	cf, server, err := testutil.NewTestServerAndClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	var b bytes.Buffer
+	cmdr := FakeDeisCmd{WOut: &b, ConfigFile: cf}
+
+	// cases defines the arguments and expected return of the call.
+	// if expected is "", it defaults to args[0].
+	cases := []struct {
+		args     []string
+		expected string
+	}{
+		{
+			args:     []string{"labels:list"},
+			expected: "",
+		},
+		{
+			args:     []string{"labels:set", "git_repo=https://github.com/deis/workflow", "team=deis"},
+			expected: "",
+		},
+		{
+			args:     []string{"labels:unset", "git_repo", "team"},
+			expected: "",
+		},
+		{
+			args:     []string{"labels"},
+			expected: "labels:list",
+		},
+	}
+
+	// For each case, check that calling the route with the arguments
+	// returns the expected error, which is args[0] if not provided.
+	for _, c := range cases {
+		var expected string
+		if c.expected == "" {
+			expected = c.args[0]
+		} else {
+			expected = c.expected
+		}
+		err = Labels(c.args, cmdr)
+		assert.Err(t, errors.New(expected), err)
+	}
+}


### PR DESCRIPTION
Add Label model for workflow-cli new command Label.
Labels are general key value string to each app just for administration purpose.

Require https://github.com/deis/controller-sdk-go/pull/106
See https://github.com/deis/workflow/issues/597