### PR TITLE
feat(run-cmd): Allow using an unreleased image

### DIFF
--- a/cmd/apps.go
+++ b/cmd/apps.go
@@ -190,7 +190,7 @@ func (d *DeisCmd) AppLogs(appID string, lines int) error {
 }
 
 // AppRun runs a one time command in the app.
-func (d *DeisCmd) AppRun(appID, command string) error {
+func (d *DeisCmd) AppRun(appID, image string, command string) error {
 	s, appID, err := load(d.ConfigFile, appID)
 
 	if err != nil {
@@ -199,7 +199,7 @@ func (d *DeisCmd) AppRun(appID, command string) error {
 
 	d.Printf("Running '%s'...\n", command)
 
-	out, err := apps.Run(s.Client, appID, command)
+	out, err := apps.Run(s.Client, appID, image, command)
 	if d.checkAPICompatibility(s.Client, err) != nil {
 		return err
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -15,7 +15,7 @@ type Commander interface {
 	AppInfo(string) error
 	AppOpen(string) error
 	AppLogs(string, int) error
-	AppRun(string, string) error
+	AppRun(string, string, string) error
 	AppDestroy(string, string) error
 	AppTransfer(string, string) error
 	AutoscaleList(string) error

--- a/parser/apps.go
+++ b/parser/apps.go
@@ -212,6 +212,8 @@ Arguments:
     the shell command to run inside the container.
 
 Options:
+  -i --image=<image>
+    the docker image to use, defaults to current release image
   -a --app=<app>
     the uniquely identifiable name for the application.
 `
@@ -223,9 +225,10 @@ Options:
 	}
 
 	app := safeGetValue(args, "--app")
+	image := safeGetValue(args, "--image")
 	command := strings.Join(args["<command>"].([]string), " ")
 
-	return cmdr.AppRun(app, command)
+	return cmdr.AppRun(app, image, command)
 }
 
 func appDestroy(argv []string, cmdr cmd.Commander) error {

--- a/parser/apps_test.go
+++ b/parser/apps_test.go
@@ -32,7 +32,7 @@ func (d FakeDeisCmd) AppLogs(string, int) error {
 	return errors.New("apps:logs")
 }
 
-func (d FakeDeisCmd) AppRun(string, string) error {
+func (d FakeDeisCmd) AppRun(string, string, string) error {
 	return errors.New("apps:run")
 }
 
@@ -87,6 +87,10 @@ func TestApps(t *testing.T) {
 		},
 		{
 			args:     []string{"apps:run", "ls"},
+			expected: "",
+		},
+		{
+			args:     []string{"apps:run", "--image=x:y", "ls"},
 			expected: "",
 		},
 		{


### PR DESCRIPTION
This is useful for build steps which must be completed before an app is fully
deployed to deis, for example asset compilation.

Builds on: https://github.com/deis/controller/pull/1208