### PR TITLE
fix(cmd): check for invalid probe types

### DIFF
--- a/cmd/healthchecks_test.go
+++ b/cmd/healthchecks_test.go
@@ -307,7 +307,7 @@ func TestHealthchecksUnset(t *testing.T) {
 }`)
 	})
 
-	err = cmdr.HealthchecksUnset("foo", "web/cmd", []string{"web/cmd"})
+	err = cmdr.HealthchecksUnset("foo", "web/cmd", []string{"liveness"})
 	assert.NoErr(t, err)
 	assert.Equal(t, testutil.StripProgress(b.String()), `Removing healthchecks... done
 

--- a/parser/healthchecks_test.go
+++ b/parser/healthchecks_test.go
@@ -70,6 +70,14 @@ func TestHealthchecks(t *testing.T) {
 			args:     []string{"healthchecks"},
 			expected: "healthchecks:list",
 		},
+		{
+			args:     []string{"healthchecks:set", "alien", "httpGet", "80"},
+			expected: "probe type alien is invalid. Must be one of [liveness readiness]",
+		},
+		{
+			args:     []string{"healthchecks:unset", "alien", "httpGet", "80"},
+			expected: "probe type alien is invalid. Must be one of [liveness readiness]",
+		},
 	}
 
 	// For each case, check that calling the route with the arguments


### PR DESCRIPTION
closes deis/workflow#704