### PR TITLE
feat(cmd): add config:list --diff

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,7 +36,7 @@ type Commander interface {
 	CertInfo(string) error
 	CertAttach(string, string) error
 	CertDetach(string, string) error
-	ConfigList(string, bool) error
+	ConfigList(string, string) error
 	ConfigSet(string, []string) error
 	ConfigUnset(string, []string) error
 	ConfigPull(string, bool, bool) error

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -87,7 +87,7 @@ func TestConfigList(t *testing.T) {
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
 
-	err = cmdr.ConfigList("foo", false)
+	err = cmdr.ConfigList("foo", "")
 	assert.NoErr(t, err)
 
 	assert.Equal(t, b.String(), `=== foo Config
@@ -98,9 +98,15 @@ TRUE       false
 `, "output")
 	b.Reset()
 
-	err = cmdr.ConfigList("foo", true)
+	err = cmdr.ConfigList("foo", "oneline")
 	assert.NoErr(t, err)
 	assert.Equal(t, b.String(), "FLOAT=12.34 NCC=1701 TEST=testing TRUE=false\n", "output")
+
+	b.Reset()
+
+	err = cmdr.ConfigList("foo", "diff")
+	assert.NoErr(t, err)
+	assert.Equal(t, b.String(), "FLOAT=12.34\nNCC=1701\nTEST=testing\nTRUE=false\n", "output")
 }
 
 func TestConfigSet(t *testing.T) {

--- a/parser/config.go
+++ b/parser/config.go
@@ -54,6 +54,8 @@ Usage: deis config:list [options]
 Options:
   --oneline
     print output on one line.
+  --diff
+    print output on multiple lines for comparison against .env files.
   -a --app=<app>
     the uniquely identifiable name of the application.
 `
@@ -65,8 +67,16 @@ Options:
 	}
 	app := safeGetValue(args, "--app")
 	oneline := args["--oneline"].(bool)
+	diff := args["--diff"].(bool)
 
-	return cmdr.ConfigList(app, oneline)
+	format := ""
+	if oneline {
+		format = "oneline"
+	} else if diff {
+		format = "diff"
+	}
+
+	return cmdr.ConfigList(app, format)
 }
 
 func configSet(argv []string, cmdr cmd.Commander) error {

--- a/parser/config_test.go
+++ b/parser/config_test.go
@@ -12,7 +12,7 @@ import (
 // Create fake implementations of each method that return the argument
 // we expect to have called the function (as an error to satisfy the interface).
 
-func (d FakeDeisCmd) ConfigList(string, bool) error {
+func (d FakeDeisCmd) ConfigList(string, string) error {
 	return errors.New("config:list")
 }
 


### PR DESCRIPTION
closes #293 

Usage:

```
$ deis config:pull
$ diff <(deis config:list --diff) .env
$ vim .env
$ diff <(deis config:list --diff) .env
3c3
< HELLO=world
---
> HELLO=deis
```