### PR TITLE
fix(cmd) Fix proctype regex for setting limits

### DIFF
--- a/cmd/limits.go
+++ b/cmd/limits.go
@@ -145,7 +145,7 @@ func parseLimits(limits []string) (map[string]interface{}, error) {
 }
 
 func parseLimit(limit string) (string, string, error) {
-	regex := regexp.MustCompile("^([A-z]+)=(([0-9]+[bkmgBKMG]{1,2}|[0-9.]{1,5}|[0-9.]{1,5}m?)(/([0-9]+[bkmgBKMG]{1,2}|[0-9.]{1,5}|[0-9.]{1,5}m?}))?)$")
+	regex := regexp.MustCompile("^([a-z0-9]+(?:-[a-z0-9]+)*)=(([0-9]+[bkmgBKMG]{1,2}|[0-9.]{1,5}|[0-9.]{1,5}m?)(/([0-9]+[bkmgBKMG]{1,2}|[0-9.]{1,5}|[0-9.]{1,5}m?}))?)$")
 
 	if !regex.MatchString(limit) {
 		return "", "", fmt.Errorf(`%s doesn't fit format type=#unit or type=# or type=#/#

--- a/cmd/limits_test.go
+++ b/cmd/limits_test.go
@@ -36,12 +36,18 @@ Examples: web=2G worker=500M db=1G/2G`
 		{"web=200m/400m", "web", "200m/400m", false, ""},
 		{"web=0.2/0.4", "web", "0.2/0.4", false, ""},
 		{"web=.2/.4", "web", ".2/.4", false, ""},
+		{"web1=2G", "web1", "2G", false, ""},
+		{"web-server=2G", "web-server", "2G", false, ""},
+		{"web-server1=2G", "web-server1", "2G", false, ""},
 		{"=1", "", "", true, "=1" + errorHint},
 		{"web=", "", "", true, "web=" + errorHint},
 		{"1=", "", "", true, "1=" + errorHint},
 		{"web=G", "", "", true, "web=G" + errorHint},
 		{"web=/", "", "", true, "web=/" + errorHint},
 		{"web=/1", "", "", true, "web=/1" + errorHint},
+		{"web-=2G", "", "", true, "web-=2G" + errorHint},
+		{"-web=2G", "", "", true, "-web=2G" + errorHint},
+		{"Web=2G", "", "", true, "Web=2G" + errorHint},
 	}
 
 	for _, check := range cases {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -142,13 +142,13 @@ func parseType(target string, appID string) (string, string) {
 
 func parsePsTargets(targets []string) (map[string]int, error) {
 	targetMap := make(map[string]int)
-	regex := regexp.MustCompile(`^([a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*)=([0-9]+)$`)
+	regex := regexp.MustCompile(`^([a-z0-9]+(?:-[a-z0-9]+)*)=([0-9]+)$`)
 	var err error
 
 	for _, target := range targets {
 		if regex.MatchString(target) {
 			captures := regex.FindStringSubmatch(target)
-			targetMap[captures[1]], err = strconv.Atoi(captures[3])
+			targetMap[captures[1]], err = strconv.Atoi(captures[2])
 
 			if err != nil {
 				return nil, err

--- a/cmd/ps_test.go
+++ b/cmd/ps_test.go
@@ -119,9 +119,10 @@ func TestParsePsTargets(t *testing.T) {
 		{[]string{"test"}, true, nil, "'test' does not match the pattern 'type=num', ex: web=2\n"},
 		{[]string{"test=a"}, true, nil, "'test=a' does not match the pattern 'type=num', ex: web=2\n"},
 		{[]string{"test="}, true, nil, "'test=' does not match the pattern 'type=num', ex: web=2\n"},
+		{[]string{"Test=2"}, true, nil, "'Test=2' does not match the pattern 'type=num', ex: web=2\n"},
 		{[]string{"test=2"}, false, map[string]int{"test": 2}, ""},
 		{[]string{"test-proc=2"}, false, map[string]int{"test-proc": 2}, ""},
-		{[]string{"Test1=2"}, false, map[string]int{"Test1": 2}, ""},
+		{[]string{"test1=2"}, false, map[string]int{"test1": 2}, ""},
 	}
 
 	for _, check := range cases {


### PR DESCRIPTION
This fixes the proctype regex to match [the one used by deis/controller](https://github.com/deis/controller/blob/master/rootfs/api/serializers.py#L21).

This fixes an issue reported by @tylux on slack where setting limits for a proctype called "worker1" failed with:

```
Error: worker1=100M/350M doesn’t fit format type=#unit or type=# or type=#/#
```

I've also added a few test cases that check for good and bad proctypes.