### PR TITLE
feat(cmd): Support Base64 encoded SSH_KEY

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -76,34 +76,11 @@ func (d *DeisCmd) ConfigSet(appID string, configVars []string) error {
 		return err
 	}
 
-	value, ok := configMap["SSH_KEY"]
-
-	if ok {
-		sshKey := value.(string)
-		sshRegex := regexp.MustCompile("^-.+ .SA PRIVATE KEY-*")
-
-		if _, err = os.Stat(value.(string)); err == nil {
-			contents, err := ioutil.ReadFile(value.(string))
-
-			if err != nil {
-				return err
-			}
-
-			sshKey = string(contents)
-		} else {
-			// NOTE(felixbuenemann): check if the current value is already a base64 encoded key.
-			// This is the case if it was fetched using "deis config:pull".
-			contents, err := base64.StdEncoding.DecodeString(sshKey)
-
-			if err == nil && sshRegex.MatchString(string(contents)) {
-				sshKey = string(contents)
-			}
+	if value, ok := configMap["SSH_KEY"]; ok {
+		sshKey, err := parseSSHKey(value.(string))
+		if err != nil {
+			return err
 		}
-
-		if !sshRegex.MatchString(sshKey) {
-			return fmt.Errorf("Could not parse SSH private key:\n %s", sshKey)
-		}
-
 		configMap["SSH_KEY"] = base64.StdEncoding.EncodeToString([]byte(sshKey))
 	}
 
@@ -296,6 +273,37 @@ func parseConfig(configVars []string) (map[string]interface{}, error) {
 	}
 
 	return configMap, nil
+}
+
+func parseSSHKey(value string) (string, error) {
+	sshRegex := regexp.MustCompile("^-----BEGIN (DSA|RSA|EC|OPENSSH) PRIVATE KEY-----")
+
+	if sshRegex.MatchString(value) {
+		return value, nil
+	}
+
+	// NOTE(felixbuenemann): check if the current value is already a base64 encoded key.
+	// This is the case if it was fetched using "deis config:pull".
+	contents, err := base64.StdEncoding.DecodeString(value)
+
+	if err == nil && sshRegex.MatchString(string(contents)) {
+		return string(contents), nil
+	}
+
+	// NOTE(felixbuenemann): check if the value is a path to a private key.
+	if _, err := os.Stat(value); err == nil {
+		contents, err := ioutil.ReadFile(value)
+
+		if err != nil {
+			return "", err
+		}
+
+		if sshRegex.MatchString(string(contents)) {
+			return string(contents), nil
+		}
+	}
+
+	return "", fmt.Errorf("Could not parse SSH private key:\n %s", value)
 }
 
 func formatConfig(configVars map[string]interface{}) string {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -154,7 +154,8 @@ func TestConfigSet(t *testing.T) {
 		if r.Method == "POST" {
 			testutil.AssertBody(t, api.Config{
 				Values: map[string]interface{}{
-					"TRUE": "false",
+					"TRUE":    "false",
+					"SSH_KEY": "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0=",
 				},
 			}, r)
 		}
@@ -166,6 +167,7 @@ func TestConfigSet(t *testing.T) {
 			"TEST":  "testing",
 			"NCC":   "1701",
 			"TRUE":  "false",
+			"SSH_KEY": "LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0=",
 			"FLOAT": "12.34"
 	},
 	"memory": {},
@@ -181,16 +183,17 @@ func TestConfigSet(t *testing.T) {
 	var b bytes.Buffer
 	cmdr := DeisCmd{WOut: &b, ConfigFile: cf}
 
-	err = cmdr.ConfigSet("foo", []string{"TRUE=false"})
+	err = cmdr.ConfigSet("foo", []string{"TRUE=false", "SSH_KEY=-----BEGIN OPENSSH PRIVATE KEY-----"})
 	assert.NoErr(t, err)
 
 	assert.Equal(t, testutil.StripProgress(b.String()), `Creating config... done
 
 === foo Config
-FLOAT      12.34
-NCC        1701
-TEST       testing
-TRUE       false
+FLOAT        12.34
+NCC          1701
+SSH_KEY      LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0=
+TEST         testing
+TRUE         false
 `, "output")
 }
 


### PR DESCRIPTION
This adds a check to see if the value of SSH_KEY is already a Base64
encoded value, which is the case if "deis config:push" is used after
using "deis config:pull" on an app that already has SSH_KEY set.

This fixes #274.